### PR TITLE
6 differentiate terrain from other eg building walker entities

### DIFF
--- a/src/components/sprite.h
+++ b/src/components/sprite.h
@@ -4,9 +4,15 @@
 struct Sprite {
     int height_px;
     int width_px;
+    int texture_id;
     int vertical_offset_px;
     int horitonzal_offset_px;
-    int texture_id;
+};
+
+struct TerrainSprite: public Sprite {   
+};
+
+struct VerticalSprite: public Sprite {
 };
 
 #endif

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -187,6 +187,7 @@ void Game::initialise() {
         textures[15], NULL, NULL, &width_px, &height_px
     );
 
+    // TODO: remove
     entt::entity entity {registry.create()};
     glm::vec2 position {grid_pos_to_pixels(5, 2)};
     position.x += ((TILE_WIDTH / 2) - (width_px / 2));

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -211,6 +211,18 @@ void Game::process_input() {
     }
 }
 
+void apply_velocity(
+    entt::view<entt::get_t<RigidBody, Transform>> moveable_entities, 
+    double delta_time
+) {
+    for (entt::entity entity: moveable_entities) {
+        RigidBody& rigid_body = moveable_entities.get<RigidBody>(entity);
+        Transform& transform = moveable_entities.get<Transform>(entity);
+        transform.position.x += (rigid_body.velocity.x * delta_time);
+        transform.position.y += (rigid_body.velocity.y * delta_time);
+    }
+}
+
 void Game::update() {
     // Calculate the amount of time to delay (assuming positive)
     int time_to_delay {
@@ -231,13 +243,8 @@ void Game::update() {
     
     // To be extracted to its own function call
     // movement logic
-    auto moveable_entities = registry.view<RigidBody, Transform>();
-    for (entt::entity entity: moveable_entities) {
-        RigidBody& rigid_body = moveable_entities.get<RigidBody>(entity);
-        Transform& transform = moveable_entities.get<Transform>(entity);
-        transform.position.x += (rigid_body.velocity.x * delta_time);
-        transform.position.y += (rigid_body.velocity.y * delta_time);
-    }
+    apply_velocity(registry.view<RigidBody, Transform>(), delta_time);
+
 
     // Update the member to indicate the time the last update was run
     millis_previous_frame = SDL_GetTicks();

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2,30 +2,32 @@
 #include "spdlog/spdlog.h"
 #include <string>
 #include <SDL2/SDL_image.h>
+#include <entt/entt.hpp>
+
 #include "../components/transform.h"
 #include "../components/sprite.h"
 #include "../components/rigid_body.h"
 
-TileMap::TileMap() {
+TileMap::TileMap(entt::registry& registry) {
     spdlog::info("TileMap constructor called.");
-    tilemap = std::vector<std::vector<int>>(
-        MAP_SIZE, std::vector<int>(MAP_SIZE,1)
-    );
+    for (int x=0; x<MAP_SIZE; x++) {
+        std::vector<entt::entity> row;
+        for (int y=0; y<MAP_SIZE; y++) {
+            row.push_back(registry.create());
+        }
+        tilemap.push_back(row);
+    }
 }
 
 TileMap::~TileMap() {
     spdlog::info("TileMap destructor called.");
 }
 
-int TileMap::coordinate_value(const int x, const int y) const {
-    return tilemap.at(y).at(x);
+entt::entity TileMap::at(const int x, const int y) {
+    return tilemap.at(x).at(y);
 }
 
-void TileMap::set(const int x, const int y, const int value) {
-    tilemap[x][y] = value;
-}
-
-Game::Game() {
+Game::Game(): registry{entt::registry()}, tilemap{registry} {
     spdlog::info("Game constructor called.");
 }
 
@@ -35,21 +37,22 @@ Game::~Game() {
 
 void Game::load_textures(){
     std::vector<std::string> tile_paths {
-        "./assets/road.png",                // 0
-        "./assets/green.png",               // 1
-        "./assets/blue.png",                // 2
-        "./assets/pink.png",                // 3
-        "./assets/tallest_tile.png",        // 4
-        "./assets/tall_tile.png",           // 5
-        "./assets/taller_tile.png",         // 6
-        "./assets/BLBR.png",                // 7
-        "./assets/BLTL.png",                // 8
-        "./assets/BLTR.png",                // 9
-        "./assets/BRTR.png",                // 10
-        "./assets/TLBR.png",                // 11
-        "./assets/TLTR.png",                // 12
-        "./assets/BLBRTR.png",              // 13
-        "./assets/moveable_sprite_test.png" // 14
+        "./assets/road.png",                        // 0
+        "./assets/green.png",                       // 1
+        "./assets/blue.png",                        // 2
+        "./assets/pink.png",                        // 3
+        "./assets/tallest_tile.png",                // 4
+        "./assets/tall_tile.png",                   // 5
+        "./assets/taller_tile.png",                 // 6
+        "./assets/BLBR.png",                        // 7
+        "./assets/BLTL.png",                        // 8
+        "./assets/BLTR.png",                        // 9
+        "./assets/BRTR.png",                        // 10
+        "./assets/TLBR.png",                        // 11
+        "./assets/TLTR.png",                        // 12
+        "./assets/BLBRTR.png",                      // 13
+        "./assets/moveable_sprite_test.png",        // 14
+        "./assets/moveable_sprite_tall_test.png"    // 15
     };
 
     for (unsigned int texture_id=0; texture_id<tile_paths.size(); texture_id++) {
@@ -74,19 +77,22 @@ void Game::load_textures(){
     }
 }
 
-void Game::load_tilemap() {
+glm::vec2 grid_pos_to_pixels(const int x, const int y) {
+    int x_offset {x-y};
+    int y_offset {y+x};
+    return glm::vec2 {
+        TILEMAP_X_START + (x_offset * (TILE_WIDTH / 2)),
+        TILEMAP_Y_START + (y_offset * (TILE_HEIGHT / 2))
+    };
+}
 
+void Game::load_tilemap() {
+    spdlog::info("Loading tilemap");
     for (int y=0; y<static_cast<int>(MAP_SIZE); y++) {
         for (int x=0; x<static_cast<int>(MAP_SIZE); x++) {
 
-            int x_offset {x-y};
-            int y_offset {y+x};
-            int texture_id {terrain.coordinate_value(x, y)};
-
-            glm::vec2 position{
-                TILEMAP_X_START + (x_offset * (TILE_WIDTH / 2)),
-                TILEMAP_Y_START + (y_offset * (TILE_HEIGHT / 2))
-            };
+            glm::vec2 position {grid_pos_to_pixels(x, y)};
+            int texture_id {1};
 
             int height_px;
             int width_px;
@@ -98,17 +104,48 @@ void Game::load_tilemap() {
             int vertical_offset_px {TILE_HEIGHT - height_px};
             int horizontal_offset_px {TILE_WIDTH - width_px};
 
-            auto entity {registry.create()};
+            entt::entity entity {tilemap.at(x, y)};
+            
             registry.emplace<Transform>(entity, position, 0.0);
-            registry.emplace<Sprite>(
+            registry.emplace<TerrainSprite>(
                 entity,
                 height_px,
                 width_px,
+                texture_id,
                 vertical_offset_px,
-                horizontal_offset_px,
-                texture_id
+                horizontal_offset_px
             );
         }
+    }
+
+    for (int n=0; n<3; n++) {
+        entt::entity entity_1 {tilemap.at(n, 3)};
+        entt::entity entity_2 {tilemap.at(n, 1)};
+
+        int height_px;
+        int width_px;
+
+        SDL_QueryTexture(
+            textures[n+4], NULL, NULL, &width_px, &height_px
+        );
+
+        registry.emplace<VerticalSprite>(
+            entity_1,
+            height_px,
+            width_px,
+            n+4,
+            TILE_HEIGHT - height_px,
+            TILE_WIDTH - width_px
+        );
+
+        registry.emplace<VerticalSprite>(
+            entity_2,
+            height_px,
+            width_px,
+            n+4,
+            TILE_HEIGHT - height_px,
+            TILE_WIDTH - width_px
+        );
     }
 }
 
@@ -141,10 +178,23 @@ void Game::initialise() {
     }
 
     load_textures();
-    terrain.set(0, 0, 2);
-    terrain.set(1, 1, 2);
     load_tilemap();
 
+    int height_px;
+    int width_px;
+
+    SDL_QueryTexture(
+        textures[15], NULL, NULL, &width_px, &height_px
+    );
+
+    entt::entity entity {registry.create()};
+    glm::vec2 position {grid_pos_to_pixels(5, 2)};
+    position.x += ((TILE_WIDTH / 2) - (width_px / 2));
+    position.y -= ((TILE_HEIGHT / 2));
+    registry.emplace<Transform>(entity, position, 0.0);
+    registry.emplace<VerticalSprite>(entity, height_px, width_px, 15, TILE_HEIGHT-height_px, 0);
+    registry.emplace<RigidBody>(entity, glm::vec2(-40, -20));
+    
     // TODO: initialise ImGui
 }
 
@@ -181,57 +231,78 @@ void Game::update() {
     
     // To be extracted to its own function call
     // movement logic
+    auto moveable_entities = registry.view<RigidBody, Transform>();
+    for (entt::entity entity: moveable_entities) {
+        RigidBody& rigid_body = moveable_entities.get<RigidBody>(entity);
+        Transform& transform = moveable_entities.get<Transform>(entity);
+        transform.position.x += (rigid_body.velocity.x * delta_time);
+        transform.position.y += (rigid_body.velocity.y * delta_time);
+    }
 
     // Update the member to indicate the time the last update was run
     millis_previous_frame = SDL_GetTicks();
+
+}
+
+int transform_abspixel(const Transform& transform) {
+    return static_cast<int>(
+        (transform.position.y * WINDOW_WIDTH) + transform.position.x
+    );
 }
 
 bool transform_y_comparison(const Transform& lhs, const Transform& rhs) {
-    int lhs_abspixel {
-        static_cast<int>((lhs.position.y * WINDOW_WIDTH) + lhs.position.x)
+    int lhs_abspixel {transform_abspixel(lhs)};
+    int rhs_abspixel {transform_abspixel(rhs)};
+    return lhs_abspixel < rhs_abspixel;
+}
+
+void render_sprite(
+    SDL_Renderer* renderer, 
+    const std::unordered_map<int, SDL_Texture*>& textures,
+    const Transform& transform, 
+    const Sprite& sprite
+) {
+
+    SDL_Rect source_rect {0, 0, sprite.width_px, sprite.height_px};
+    SDL_Rect dest_rect {
+        static_cast<int>(transform.position.x) + sprite.horitonzal_offset_px, 
+        static_cast<int>(transform.position.y) + sprite.vertical_offset_px, 
+        sprite.width_px,
+        sprite.height_px
     };
 
-    int rhs_abspixel {
-        static_cast<int>((rhs.position.y * WINDOW_WIDTH) + rhs.position.x)
-    };
-    
-    return rhs_abspixel > lhs_abspixel;
+    SDL_Texture* texture {textures.find(sprite.texture_id)->second};
+
+    SDL_RenderCopyEx(
+        renderer,
+        texture,
+        &source_rect,
+        &dest_rect,
+        transform.rotation,
+        NULL,
+        SDL_FLIP_NONE
+    );
 }
 
 void Game::render() {
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
     SDL_RenderClear(renderer);
 
-    // TODO: implement rendering logic
-    // ...
-
     registry.sort<Transform>(transform_y_comparison);
 
-    auto view {registry.view<Transform, Sprite>()};
+    auto terrain_tiles = registry.view<Transform, TerrainSprite>();
+    for (auto entity: terrain_tiles) {
+        auto& transform {terrain_tiles.get<Transform>(entity)};
+        auto& sprite {terrain_tiles.get<TerrainSprite>(entity)};
+        render_sprite(renderer, textures, transform, sprite);
+    }
 
-    for (auto entity: view) {
-        auto& transform {view.get<Transform>(entity)};
-        auto& sprite {view.get<Sprite>(entity)};
-
-        // Assume we fetch the whole texture from the top left
-        SDL_Rect source_rect{0, 0, sprite.width_px, sprite.height_px};
-
-        SDL_Rect dest_rect{
-            static_cast<int>(transform.position.x) + sprite.horitonzal_offset_px, 
-            static_cast<int>(transform.position.y) + sprite.vertical_offset_px, 
-            sprite.width_px,
-            sprite.height_px
-        };
-
-        SDL_RenderCopyEx(
-            renderer,
-            textures[sprite.texture_id],
-            &source_rect,
-            &dest_rect,
-            transform.rotation,
-            NULL,
-            SDL_FLIP_NONE
-        );
+    auto vertical_tiles = registry.view<Transform, VerticalSprite>();
+    vertical_tiles.use<Transform>();
+    for (auto entity: vertical_tiles) {
+        auto& transform {vertical_tiles.get<Transform>(entity)};
+        auto& sprite {vertical_tiles.get<VerticalSprite>(entity)};
+        render_sprite(renderer, textures, transform, sprite);
     }
 
     SDL_RenderPresent(renderer);

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -16,13 +16,12 @@ constexpr int TILEMAP_X_START   {(WINDOW_WIDTH / 2) - (TILE_WIDTH / 2)};
 constexpr int TILEMAP_Y_START   {100};
 
 class TileMap {
-    std::vector<std::vector<int>> tilemap;
+    std::vector<std::vector<entt::entity>> tilemap;
 
-    public: 
-        TileMap();
+    public:
+        entt::entity at(const int x, const int y);
+        TileMap(entt::registry& registry);
         ~TileMap();
-        int coordinate_value(const int x, const int y) const;
-        void set(const int x, const int y, const int value);
 };
 
 class Game {
@@ -32,12 +31,14 @@ class Game {
     // Has to be default initialised because it's referenced in Game::update()
     int millis_previous_frame{};    
 
+    // TODO: the EnTT registry
+    entt::registry registry;
+
     SDL_Renderer* renderer;
     SDL_Window* window;
     SDL_Rect camera{}; // Investigate whether this should be default-initialised
 
-    TileMap terrain;
-    TileMap mutable_elements;
+    TileMap tilemap;
 
     void load_textures();
     void load_tilemap();
@@ -47,9 +48,6 @@ class Game {
 
     // Todo: read re. asset stores
     std::unordered_map<int, SDL_Texture*> textures;
-
-    // TODO: the EnTT registry
-    entt::registry registry;
 
     public:
         Game();

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -11,6 +11,19 @@ constexpr int WINDOW_HEIGHT     {768};
 constexpr int WINDOW_WIDTH      {1024};
 constexpr int TILE_HEIGHT       {60};
 constexpr int TILE_WIDTH        {120};
+constexpr int MAP_SIZE          {5};
+constexpr int TILEMAP_X_START   {(WINDOW_WIDTH / 2) - (TILE_WIDTH / 2)};
+constexpr int TILEMAP_Y_START   {100};
+
+class TileMap {
+    std::vector<std::vector<int>> tilemap;
+
+    public: 
+        TileMap();
+        ~TileMap();
+        int coordinate_value(const int x, const int y) const;
+        void set(const int x, const int y, const int value);
+};
 
 class Game {
     bool is_running {false};
@@ -22,6 +35,9 @@ class Game {
     SDL_Renderer* renderer;
     SDL_Window* window;
     SDL_Rect camera{}; // Investigate whether this should be default-initialised
+
+    TileMap terrain;
+    TileMap mutable_elements;
 
     void load_textures();
     void load_tilemap();

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -5,6 +5,9 @@
 #include <entt/entt.hpp>
 #include <unordered_map>
 
+#include "../components/transform.h"
+#include "../components/sprite.h"
+
 constexpr int FPS               {60};
 constexpr int MILLIS_PER_FRAME  {1'000/FPS};
 constexpr int WINDOW_HEIGHT     {768};
@@ -37,6 +40,8 @@ class Game {
     SDL_Renderer* renderer;
     SDL_Window* window;
     SDL_Rect camera{}; // Investigate whether this should be default-initialised
+    // Todo: read re. asset stores
+    std::unordered_map<int, SDL_Texture*> textures;
 
     TileMap tilemap;
 
@@ -45,9 +50,6 @@ class Game {
     void process_input();
     void update();
     void render();
-
-    // Todo: read re. asset stores
-    std::unordered_map<int, SDL_Texture*> textures;
 
     public:
         Game();


### PR DESCRIPTION
Purpose of the changes in this PR is to introduce a means through which buildings and walkers can be differentiated.

In the PR, this was achieved by creating multiple sprite "types" (Terrain, Vertical).

A single entity (which can be used to represent a tile on the grid) can have both a terrain and a vertical sprite component, meaning that:

1. Sprites with a "vertical" component (a height exceeding the standard tile height) can be rendered independently of terrain
2. A single tile can have both a terrain/vertical component, meaning the vertical component can utilise image alpha to expose some of the terrain underneath (if required)

There is a lot of "instance" code in used for the purposes of testing which should be removed in time!