### PR TITLE
12 use sdl rendersetcliprect

### DIFF
--- a/src/game/camera.cpp
+++ b/src/game/camera.cpp
@@ -1,27 +1,35 @@
 #include "camera.h"
 #include "constants.h"
 
-void Camera::set_position(const glm::ivec2& mouse_position) {
-    if (mouse_position.x < constants::CAMERA_BORDER_PX) {
-        --camera_position.x;
+void Camera::set_position(
+    const glm::ivec2& mouse_screen_position
+) {
+    if (
+        mouse_screen_position.x < constants::CAMERA_BORDER_PX &&
+        camera_position.x > 0
+    ) {
+        camera_position.x -= 4;
     }
 
     if (
-        (constants::WINDOW_WIDTH - mouse_position.x) < 
-        constants::CAMERA_BORDER_PX
+        (constants::WINDOW_WIDTH - mouse_screen_position.x) < constants::CAMERA_BORDER_PX &&
+        camera_position.x < constants::RENDER_SPACE_PX
     ) {
-        ++camera_position.x;
-    }
-
-    if (mouse_position.y < constants::CAMERA_BORDER_PX) {
-        --camera_position.y;
+        camera_position.x += 4;
     }
 
     if (
-        (constants::WINDOW_HEIGHT - mouse_position.y) <
-        constants::CAMERA_BORDER_PX
+        mouse_screen_position.y < constants::CAMERA_BORDER_PX &&
+        camera_position.y > 0
     ) {
-        ++camera_position.y;
+        camera_position.y -= 4;
+    }
+
+    if (
+        (constants::WINDOW_HEIGHT - mouse_screen_position.y) < constants::CAMERA_BORDER_PX &&
+        camera_position.y < constants::RENDER_SPACE_PX
+    ) {
+        camera_position.y += 4;
     }
 }
 

--- a/src/game/camera.cpp
+++ b/src/game/camera.cpp
@@ -1,0 +1,30 @@
+#include "camera.h"
+#include "constants.h"
+
+void Camera::set_position(const glm::ivec2& mouse_position) {
+    if (mouse_position.x < constants::CAMERA_BORDER_PX) {
+        --camera_position.x;
+    }
+
+    if (
+        (constants::WINDOW_WIDTH - mouse_position.x) < 
+        constants::CAMERA_BORDER_PX
+    ) {
+        ++camera_position.x;
+    }
+
+    if (mouse_position.y < constants::CAMERA_BORDER_PX) {
+        --camera_position.y;
+    }
+
+    if (
+        (constants::WINDOW_HEIGHT - mouse_position.y) <
+        constants::CAMERA_BORDER_PX
+    ) {
+        ++camera_position.y;
+    }
+}
+
+const SDL_Rect& Camera::get_position() const {
+    return camera_position;
+}

--- a/src/game/camera.h
+++ b/src/game/camera.h
@@ -6,10 +6,15 @@
 #include "constants.h"
 
 class Camera {
-    SDL_Rect camera_position {0, 0, constants::WINDOW_WIDTH, constants::WINDOW_HEIGHT};
+    SDL_Rect camera_position {
+        ((constants::RENDER_SPACE_PX / 2) - (constants::WINDOW_WIDTH / 2)),   // Initial X
+        0,                                                                    // Initial Y
+        constants::WINDOW_WIDTH,                                              // Width
+        constants::WINDOW_HEIGHT                                              // Height
+    };
 
     public:
-        void set_position(const glm::ivec2& mouse_position);
+        void set_position(const glm::ivec2& mouse_screen_position);
         const SDL_Rect& get_position() const;
 };
 

--- a/src/game/camera.h
+++ b/src/game/camera.h
@@ -1,0 +1,16 @@
+#ifndef CAMERA_H
+#define CAMERA_H
+
+#include <SDL2/SDL.h>
+#include <glm/glm.hpp>
+#include "constants.h"
+
+class Camera {
+    SDL_Rect camera_position {0, 0, constants::WINDOW_WIDTH, constants::WINDOW_HEIGHT};
+
+    public:
+        void set_position(const glm::ivec2& mouse_position);
+        const SDL_Rect& get_position() const;
+};
+
+#endif

--- a/src/game/constants.h
+++ b/src/game/constants.h
@@ -2,17 +2,18 @@
 #define CONSTANTS_H
 
 namespace constants {
-    inline constexpr int FPS               {60};
-    inline constexpr int MILLIS_PER_FRAME  {1'000/FPS};
-    inline constexpr int WINDOW_HEIGHT     {768};
-    inline constexpr int WINDOW_WIDTH      {1024};
-    inline constexpr int TILE_HEIGHT       {60};
-    inline constexpr int TILE_WIDTH        {120};
-    inline constexpr int TILE_HEIGHT_HALF  {TILE_HEIGHT / 2};
-    inline constexpr int TILE_WIDTH_HALF   {TILE_WIDTH / 2};
-    inline constexpr int MAP_SIZE          {5};
-    inline constexpr int TILEMAP_X_START   {(WINDOW_WIDTH / 2) - (TILE_WIDTH / 2)};
-    inline constexpr int TILEMAP_Y_START   {100};
+    inline constexpr int FPS                {60};
+    inline constexpr int MILLIS_PER_FRAME   {1'000/FPS};
+    inline constexpr int WINDOW_HEIGHT      {768};
+    inline constexpr int WINDOW_WIDTH       {1024};
+    inline constexpr int TILE_HEIGHT        {60};
+    inline constexpr int TILE_WIDTH         {120};
+    inline constexpr int TILE_HEIGHT_HALF   {TILE_HEIGHT / 2};
+    inline constexpr int TILE_WIDTH_HALF    {TILE_WIDTH / 2};
+    inline constexpr int MAP_SIZE           {30};
+    inline constexpr int TILEMAP_X_START    {(WINDOW_WIDTH / 2) - (TILE_WIDTH / 2)};
+    inline constexpr int TILEMAP_Y_START    {100};
+    inline constexpr int CAMERA_BORDER_PX   {80};     
 }
 
 #endif

--- a/src/game/constants.h
+++ b/src/game/constants.h
@@ -2,18 +2,25 @@
 #define CONSTANTS_H
 
 namespace constants {
-    inline constexpr int FPS                {60};
-    inline constexpr int MILLIS_PER_FRAME   {1'000/FPS};
-    inline constexpr int WINDOW_HEIGHT      {768};
-    inline constexpr int WINDOW_WIDTH       {1024};
-    inline constexpr int TILE_HEIGHT        {60};
-    inline constexpr int TILE_WIDTH         {120};
-    inline constexpr int TILE_HEIGHT_HALF   {TILE_HEIGHT / 2};
-    inline constexpr int TILE_WIDTH_HALF    {TILE_WIDTH / 2};
-    inline constexpr int MAP_SIZE           {30};
-    inline constexpr int TILEMAP_X_START    {(WINDOW_WIDTH / 2) - (TILE_WIDTH / 2)};
-    inline constexpr int TILEMAP_Y_START    {100};
-    inline constexpr int CAMERA_BORDER_PX   {80};     
+    inline constexpr int FPS                    {60};
+    inline constexpr int MILLIS_PER_FRAME       {1'000/FPS};
+    inline constexpr int WINDOW_HEIGHT          {768};
+    inline constexpr int WINDOW_WIDTH           {1024};
+
+    inline constexpr int TILE_HEIGHT            {60};
+    inline constexpr int TILE_WIDTH             {120};
+    inline constexpr int TILE_HEIGHT_HALF       {TILE_HEIGHT / 2};
+    inline constexpr int TILE_WIDTH_HALF        {TILE_WIDTH / 2};
+    
+    inline constexpr int MAP_BORDER_PX          {100};
+    inline constexpr int MAP_SIZE_N_TILES       {60};
+    inline constexpr int MAP_WIDTH_PX           {MAP_SIZE_N_TILES * TILE_WIDTH};
+
+    inline constexpr int RENDER_SPACE_PX        {MAP_WIDTH_PX + (MAP_BORDER_PX * 2)};
+    
+    inline constexpr int TILEMAP_X_START        {(RENDER_SPACE_PX / 2) - (TILE_WIDTH / 2)};
+    inline constexpr int TILEMAP_Y_START        {MAP_BORDER_PX};
+    inline constexpr int CAMERA_BORDER_PX       {80};
 }
 
 #endif

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -69,8 +69,8 @@ void Game::load_textures(){
 
 void Game::load_tilemap() {
     spdlog::info("Loading tilemap");
-    for (int y=0; y<constants::MAP_SIZE; y++) {
-        for (int x=0; x<constants::MAP_SIZE; x++) {
+    for (int y=0; y<constants::MAP_SIZE_N_TILES; y++) {
+        for (int x=0; x<constants::MAP_SIZE_N_TILES; x++) {
 
             glm::ivec2 position {tilemap.grid_to_pixel(x, y)};
             int texture_id {1};
@@ -233,7 +233,7 @@ void Game::update() {
     mouse.set_position(camera.get_position());
 
     // Update the camera position
-    camera.set_position(mouse.get_position());
+    camera.set_position(mouse.get_window_position());
 
     // Update the member to indicate the time the last update was run
     millis_previous_frame = SDL_GetTicks();

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -168,6 +168,8 @@ void Game::initialise() {
         textures[15], NULL, NULL, &width_px, &height_px
     );
 
+    SDL_RenderSetClipRect(renderer, &render_rect);
+
     // TODO: remove
     entt::entity entity {registry.create()};
     glm::vec2 position {tilemap.grid_to_pixel(5, 2)};
@@ -227,15 +229,39 @@ void Game::update() {
     // movement logic
     apply_velocity(registry.view<RigidBody, Transform>(), delta_time);
 
+    // Update the mouse position
+    mouse.update(camera);
+
+    // Update the camera position
+    const glm::vec2& mouse_position {mouse.get_position()};
+    if (mouse_position.x < constants::CAMERA_BORDER_PX) {
+        --camera.x;
+    }
+
+    if (
+        (constants::WINDOW_WIDTH - mouse_position.x) < 
+        constants::CAMERA_BORDER_PX
+    ) {
+        ++camera.x;
+    }
+
+    if (mouse_position.y < constants::CAMERA_BORDER_PX) {
+        --camera.y;
+    }
+
+    if (
+        (constants::WINDOW_HEIGHT - mouse_position.y) <
+        constants::CAMERA_BORDER_PX
+    ) {
+        ++camera.y;
+    }
 
     // Update the member to indicate the time the last update was run
     millis_previous_frame = SDL_GetTicks();
-    mouse.update();
 }
 
 int transform_abspixel(const Transform& transform) {
-    return 
-        (transform.position.y * constants::WINDOW_WIDTH) + transform.position.x;
+    return (transform.position.y * constants::WINDOW_WIDTH) + transform.position.x;
 }
 
 bool transform_y_comparison(const Transform& lhs, const Transform& rhs) {
@@ -245,7 +271,8 @@ bool transform_y_comparison(const Transform& lhs, const Transform& rhs) {
 }
 
 void render_sprite(
-    SDL_Renderer* renderer, 
+    SDL_Renderer* renderer,
+    const SDL_Rect& camera,
     const std::unordered_map<int, SDL_Texture*>& textures,
     const Transform& transform, 
     const Sprite& sprite
@@ -253,8 +280,8 @@ void render_sprite(
 
     SDL_Rect source_rect {0, 0, sprite.width_px, sprite.height_px};
     SDL_Rect dest_rect {
-        static_cast<int>(transform.position.x) + sprite.horitonzal_offset_px, 
-        static_cast<int>(transform.position.y) + sprite.vertical_offset_px, 
+        (static_cast<int>(transform.position.x) + sprite.horitonzal_offset_px) - camera.x, 
+        (static_cast<int>(transform.position.y) + sprite.vertical_offset_px) - camera.y, 
         sprite.width_px,
         sprite.height_px
     };
@@ -282,7 +309,7 @@ void Game::render() {
     for (auto entity: terrain_tiles) {
         auto& transform {terrain_tiles.get<Transform>(entity)};
         auto& sprite {terrain_tiles.get<TerrainSprite>(entity)};
-        render_sprite(renderer, textures, transform, sprite);
+        render_sprite(renderer, camera, textures, transform, sprite);
     }
 
     auto vertical_tiles = registry.view<Transform, VerticalSprite>();
@@ -290,7 +317,7 @@ void Game::render() {
     for (auto entity: vertical_tiles) {
         auto& transform {vertical_tiles.get<Transform>(entity)};
         auto& sprite {vertical_tiles.get<VerticalSprite>(entity)};
-        render_sprite(renderer, textures, transform, sprite);
+        render_sprite(renderer, camera, textures, transform, sprite);
     }
 
     SDL_RenderPresent(renderer);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -230,31 +230,10 @@ void Game::update() {
     apply_velocity(registry.view<RigidBody, Transform>(), delta_time);
 
     // Update the mouse position
-    mouse.update(camera);
+    mouse.set_position(camera.get_position());
 
     // Update the camera position
-    const glm::vec2& mouse_position {mouse.get_position()};
-    if (mouse_position.x < constants::CAMERA_BORDER_PX) {
-        --camera.x;
-    }
-
-    if (
-        (constants::WINDOW_WIDTH - mouse_position.x) < 
-        constants::CAMERA_BORDER_PX
-    ) {
-        ++camera.x;
-    }
-
-    if (mouse_position.y < constants::CAMERA_BORDER_PX) {
-        --camera.y;
-    }
-
-    if (
-        (constants::WINDOW_HEIGHT - mouse_position.y) <
-        constants::CAMERA_BORDER_PX
-    ) {
-        ++camera.y;
-    }
+    camera.set_position(mouse.get_position());
 
     // Update the member to indicate the time the last update was run
     millis_previous_frame = SDL_GetTicks();
@@ -303,13 +282,15 @@ void Game::render() {
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
     SDL_RenderClear(renderer);
 
+    const SDL_Rect& camera_position {camera.get_position()};
+
     registry.sort<Transform>(transform_y_comparison);
 
     auto terrain_tiles = registry.view<Transform, TerrainSprite>();
     for (auto entity: terrain_tiles) {
         auto& transform {terrain_tiles.get<Transform>(entity)};
         auto& sprite {terrain_tiles.get<TerrainSprite>(entity)};
-        render_sprite(renderer, camera, textures, transform, sprite);
+        render_sprite(renderer, camera_position, textures, transform, sprite);
     }
 
     auto vertical_tiles = registry.view<Transform, VerticalSprite>();
@@ -317,7 +298,7 @@ void Game::render() {
     for (auto entity: vertical_tiles) {
         auto& transform {vertical_tiles.get<Transform>(entity)};
         auto& sprite {vertical_tiles.get<VerticalSprite>(entity)};
-        render_sprite(renderer, camera, textures, transform, sprite);
+        render_sprite(renderer, camera_position, textures, transform, sprite);
     }
 
     SDL_RenderPresent(renderer);

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -9,6 +9,7 @@
 #include "../components/sprite.h"
 #include "tilemap.h"
 #include "mouse.h"
+#include "constants.h"
 
 class Game {
     bool is_running {false};
@@ -20,7 +21,12 @@ class Game {
     entt::registry registry;
     SDL_Renderer* renderer;
     SDL_Window* window;
-    SDL_Rect camera{}; // Investigate whether this should be default-initialised
+
+    // Investigate whether this should be default-initialised
+    SDL_Rect camera{0, 0, constants::WINDOW_WIDTH, constants::WINDOW_HEIGHT};
+
+    // Investigate whether this is redundant!
+    SDL_Rect render_rect{20, 20, constants::WINDOW_WIDTH-40, constants::WINDOW_HEIGHT-40};
     
     // Todo: read re. asset stores
     std::unordered_map<int, SDL_Texture*> textures;

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -9,6 +9,7 @@
 #include "../components/sprite.h"
 #include "tilemap.h"
 #include "mouse.h"
+#include "camera.h"
 #include "constants.h"
 
 class Game {
@@ -23,7 +24,7 @@ class Game {
     SDL_Window* window;
 
     // Investigate whether this should be default-initialised
-    SDL_Rect camera{0, 0, constants::WINDOW_WIDTH, constants::WINDOW_HEIGHT};
+    Camera camera;
 
     // Investigate whether this is redundant!
     SDL_Rect render_rect{20, 20, constants::WINDOW_WIDTH-40, constants::WINDOW_HEIGHT-40};

--- a/src/game/mouse.cpp
+++ b/src/game/mouse.cpp
@@ -143,7 +143,7 @@ glm::ivec2 Mouse::pixel_to_grid() const {
     return coarse + pixel_colour_vector(pixel_colour);
 }
 
-void Mouse::update(const SDL_Rect& camera) {
+void Mouse::set_position(const SDL_Rect& camera) {
     previous_position = window_position;
 
     SDL_GetMouseState(&window_position.x, &window_position.y);

--- a/src/game/mouse.cpp
+++ b/src/game/mouse.cpp
@@ -94,13 +94,13 @@ glm::ivec2 Mouse::tile_walk(const glm::ivec2& tile_offset) const {
 // Public function converting x, y screen coordinates into tilemap coordinates
 glm::ivec2 Mouse::pixel_to_grid() const {
     // Coarse coordinates
-    int screen_offset_x {position.x - constants::TILEMAP_X_START};
-    int screen_offset_y {position.y - constants::TILEMAP_Y_START};
+    int screen_offset_x {world_position.x - constants::TILEMAP_X_START};
+    int screen_offset_y {world_position.y - constants::TILEMAP_Y_START};
 
     int tile_offset_x {
         static_cast<int>(
             floor(
-                screen_offset_x / <double>(constants::TILE_WIDTH)
+                screen_offset_x / static_cast<double>(constants::TILE_WIDTH)
             )
         )
     };
@@ -143,18 +143,27 @@ glm::ivec2 Mouse::pixel_to_grid() const {
     return coarse + pixel_colour_vector(pixel_colour);
 }
 
-void Mouse::update() {
-    previous_position = position;
-    SDL_GetMouseState(&position.x, &position.y);
+void Mouse::update(const SDL_Rect& camera) {
+    previous_position = window_position;
+
+    SDL_GetMouseState(&window_position.x, &window_position.y);
+
+    world_position.x = window_position.x + camera.x;
+    world_position.y = window_position.y + camera.y;
+
     glm::ivec2 grid_position {pixel_to_grid()};
 
-    if (position != previous_position) {
+    if (window_position != previous_position) {
         spdlog::info(
             "Mouse position: " + 
-            std::to_string(position.x) + ", " + 
-            std::to_string(position.y) + " (" +
+            std::to_string(window_position.x) + ", " + 
+            std::to_string(window_position.y) + " (" +
             std::to_string(grid_position.x) + ", " +
             std::to_string(grid_position.y) + ")"
         );
     }
+}
+
+const glm::ivec2& Mouse::get_position() const {
+    return window_position;
 }

--- a/src/game/mouse.cpp
+++ b/src/game/mouse.cpp
@@ -156,14 +156,18 @@ void Mouse::set_position(const SDL_Rect& camera) {
     if (window_position != previous_position) {
         spdlog::info(
             "Mouse position: " + 
-            std::to_string(window_position.x) + ", " + 
+            std::to_string(camera.x) + "," + 
+            std::to_string(camera.y) + "; " + 
+            std::to_string(world_position.x) + "," + 
+            std::to_string(world_position.y) + "; " +
+            std::to_string(window_position.x) + "," + 
             std::to_string(window_position.y) + " (" +
-            std::to_string(grid_position.x) + ", " +
+            std::to_string(grid_position.x) + "," +
             std::to_string(grid_position.y) + ")"
         );
     }
 }
 
-const glm::ivec2& Mouse::get_position() const {
+const glm::ivec2& Mouse::get_window_position() const {
     return window_position;
 }

--- a/src/game/mouse.h
+++ b/src/game/mouse.h
@@ -22,7 +22,7 @@ class Mouse {
         ~Mouse();
         glm::ivec2 pixel_to_grid() const;
         void set_position(const SDL_Rect& camera);
-        const glm::ivec2& get_position() const;
+        const glm::ivec2& get_window_position() const;
 };
 
 #endif

--- a/src/game/mouse.h
+++ b/src/game/mouse.h
@@ -21,7 +21,7 @@ class Mouse {
         Mouse(const std::string mousemap_file_path);
         ~Mouse();
         glm::ivec2 pixel_to_grid() const;
-        void update(const SDL_Rect& camera);
+        void set_position(const SDL_Rect& camera);
         const glm::ivec2& get_position() const;
 };
 

--- a/src/game/mouse.h
+++ b/src/game/mouse.h
@@ -10,7 +10,8 @@ constexpr glm::ivec2 vertical_vector{1, 1};
 
 class Mouse {
     glm::ivec2 previous_position;
-    glm::ivec2 position;
+    glm::ivec2 window_position;
+    glm::ivec2 world_position;
     SDL_Surface* mousemap;
     SDL_Color mousemap_pixel_colour(const glm::ivec2& pixel_offset) const;
     glm::ivec2 pixel_colour_vector(const SDL_Color& colour) const;
@@ -20,7 +21,8 @@ class Mouse {
         Mouse(const std::string mousemap_file_path);
         ~Mouse();
         glm::ivec2 pixel_to_grid() const;
-        void update();
+        void update(const SDL_Rect& camera);
+        const glm::ivec2& get_position() const;
 };
 
 #endif

--- a/src/game/tilemap.cpp
+++ b/src/game/tilemap.cpp
@@ -14,9 +14,9 @@ TileMap::TileMap(entt::registry& registry) {
     spdlog::info("TileMap constructor called.");
 
     // Create the entities associated with the map
-    for (int x=0; x<constants::MAP_SIZE; x++) {
+    for (int x=0; x<constants::MAP_SIZE_N_TILES; x++) {
         std::vector<entt::entity> row;
-        for (int y=0; y<constants::MAP_SIZE; y++) {
+        for (int y=0; y<constants::MAP_SIZE_N_TILES; y++) {
             row.push_back(registry.create());
         }
         tilemap.push_back(row);


### PR DESCRIPTION
This PR introduces a concept of a "camera", and uses SDL_RenderSetClipRect to ensure only visible textures are rendered.

Additionally, some existing constants have been updated/new constants added to better represent the renderable view and the game space.