### PR TITLE
Fix bug re. camera movement

### DIFF
--- a/src/game/camera.cpp
+++ b/src/game/camera.cpp
@@ -1,6 +1,5 @@
 #include "camera.h"
 #include "constants.h"
-#include <spdlog/spdlog.h>
 
 void Camera::set_position(
     const glm::ivec2& mouse_screen_position

--- a/src/game/camera.cpp
+++ b/src/game/camera.cpp
@@ -1,5 +1,6 @@
 #include "camera.h"
 #include "constants.h"
+#include <spdlog/spdlog.h>
 
 void Camera::set_position(
     const glm::ivec2& mouse_screen_position
@@ -13,7 +14,7 @@ void Camera::set_position(
 
     if (
         (constants::WINDOW_WIDTH - mouse_screen_position.x) < constants::CAMERA_BORDER_PX &&
-        camera_position.x < constants::RENDER_SPACE_PX
+        (camera_position.x + camera_position.w) < constants::RENDER_SPACE_WIDTH_PX
     ) {
         camera_position.x += 4;
     }
@@ -27,7 +28,7 @@ void Camera::set_position(
 
     if (
         (constants::WINDOW_HEIGHT - mouse_screen_position.y) < constants::CAMERA_BORDER_PX &&
-        camera_position.y < constants::RENDER_SPACE_PX
+        (camera_position.y + camera_position.h) < constants::RENDER_SPACE_HEIGHT_PX
     ) {
         camera_position.y += 4;
     }

--- a/src/game/camera.h
+++ b/src/game/camera.h
@@ -7,10 +7,10 @@
 
 class Camera {
     SDL_Rect camera_position {
-        ((constants::RENDER_SPACE_PX / 2) - (constants::WINDOW_WIDTH / 2)),   // Initial X
-        0,                                                                    // Initial Y
-        constants::WINDOW_WIDTH,                                              // Width
-        constants::WINDOW_HEIGHT                                              // Height
+        (constants::RENDER_SPACE_WIDTH_PX / 2) - (constants::WINDOW_WIDTH / 2),     // Initial X
+        0,                                                                          // Initial Y
+        constants::WINDOW_WIDTH,                                                    // Width
+        constants::WINDOW_HEIGHT                                                    // Height
     };
 
     public:

--- a/src/game/constants.h
+++ b/src/game/constants.h
@@ -15,10 +15,12 @@ namespace constants {
     inline constexpr int MAP_BORDER_PX          {100};
     inline constexpr int MAP_SIZE_N_TILES       {60};
     inline constexpr int MAP_WIDTH_PX           {MAP_SIZE_N_TILES * TILE_WIDTH};
+    inline constexpr int MAP_HEIGHT_PX          {MAP_SIZE_N_TILES * TILE_HEIGHT};
 
-    inline constexpr int RENDER_SPACE_PX        {MAP_WIDTH_PX + (MAP_BORDER_PX * 2)};
+    inline constexpr int RENDER_SPACE_WIDTH_PX  {MAP_WIDTH_PX + (MAP_BORDER_PX * 2)};
+    inline constexpr int RENDER_SPACE_HEIGHT_PX {MAP_HEIGHT_PX + (MAP_BORDER_PX * 2)};
     
-    inline constexpr int TILEMAP_X_START        {(RENDER_SPACE_PX / 2) - (TILE_WIDTH / 2)};
+    inline constexpr int TILEMAP_X_START        {(RENDER_SPACE_WIDTH_PX / 2) - (TILE_WIDTH / 2)};
     inline constexpr int TILEMAP_Y_START        {MAP_BORDER_PX};
     inline constexpr int CAMERA_BORDER_PX       {80};
 }


### PR DESCRIPTION
This PR:

1. Replaces a single "render space" constant value with two (width and height)
2. Updates the `set_position` method to account for camera height, width
3. Updates the `set_position` method to utilise render space _width_ and _height_ constants appropriately

This fixes the issue whereby the camera could be moved beyond the right-most and bottom-most extents of the renderable space.