### PR TITLE
25 automatic resolution detection fullscreen

### DIFF
--- a/src/engine/camera.cpp
+++ b/src/engine/camera.cpp
@@ -1,7 +1,16 @@
 #include "camera.h"
 #include "constants.h"
+#include <SDL2/SDL.h>
+
+Camera::Camera(const SDL_DisplayMode& display_mode): camera_position {
+    (constants::RENDER_SPACE_WIDTH_PX / 2) - (display_mode.w / 2),              // Initial X
+    0,                                                                          // Initial Y
+    display_mode.w,                                                             // Width
+    display_mode.h                                                              // Height
+} {}
 
 void Camera::update(
+    const SDL_DisplayMode& display_mode,
     const glm::ivec2& mouse_screen_position
 ) {
     if (
@@ -12,7 +21,7 @@ void Camera::update(
     }
 
     if (
-        (constants::WINDOW_WIDTH - mouse_screen_position.x) < constants::CAMERA_BORDER_PX &&
+        (display_mode.w - mouse_screen_position.x) < constants::CAMERA_BORDER_PX &&
         (camera_position.x + camera_position.w) < constants::RENDER_SPACE_WIDTH_PX
     ) {
         camera_position.x += 4;
@@ -26,7 +35,7 @@ void Camera::update(
     }
 
     if (
-        (constants::WINDOW_HEIGHT - mouse_screen_position.y) < constants::CAMERA_BORDER_PX &&
+        (display_mode.h - mouse_screen_position.y) < constants::CAMERA_BORDER_PX &&
         (camera_position.y + camera_position.h) < constants::RENDER_SPACE_HEIGHT_PX
     ) {
         camera_position.y += 4;

--- a/src/engine/camera.h
+++ b/src/engine/camera.h
@@ -6,15 +6,13 @@
 #include "constants.h"
 
 class Camera {
-    SDL_Rect camera_position {
-        (constants::RENDER_SPACE_WIDTH_PX / 2) - (constants::WINDOW_WIDTH / 2),     // Initial X
-        0,                                                                          // Initial Y
-        constants::WINDOW_WIDTH,                                                    // Width
-        constants::WINDOW_HEIGHT                                                    // Height
-    };
+    SDL_Rect camera_position;
 
     public:
-        void update(const glm::ivec2& mouse_screen_position);
+        Camera(const SDL_DisplayMode& display_mode);
+        ~Camera() = default;
+
+        void update(const SDL_DisplayMode& display_mode, const glm::ivec2& mouse_screen_position);
         const SDL_Rect& get_position() const;
 };
 

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -92,6 +92,7 @@ void Game::initialise(const std::vector<std::string>& tile_paths) {
     SDL_Init(SDL_INIT_EVERYTHING);
 
     SDL_GetDesktopDisplayMode(0, &display_mode);
+    camera = std::make_unique<Camera>(display_mode);
 
     // Create the SDL Window
     window = SDL_CreateWindow(
@@ -171,7 +172,7 @@ void Game::update() {
     };
 
     // Update the mouse position
-    mouse.update(camera.get_position());
+    mouse.update(camera->get_position());
 
     if (mouse.has_moved_this_frame() && mouse.is_on_world_grid()) {
         const glm::ivec2& grid_position {mouse.get_grid_position()};
@@ -183,7 +184,7 @@ void Game::update() {
     }
 
     // Update the camera position
-    camera.update(mouse.get_window_position());
+    camera->update(display_mode, mouse.get_window_position());
 
     // To be extracted to its own function call - movement logic
     auto entities_in_motion {registry.view<RigidBody, Transform>()};
@@ -213,7 +214,7 @@ void Game::render() {
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
     SDL_RenderClear(renderer);
 
-    const SDL_Rect& camera_position {camera.get_position()};
+    const SDL_Rect& camera_position {camera->get_position()};
 
     registry.sort<Transform>(transform_y_comparison);
 

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -200,14 +200,8 @@ void Game::update() {
     millis_previous_frame = SDL_GetTicks();
 }
 
-int transform_abspixel(const Transform& transform) {
-    return (transform.position.y * constants::WINDOW_WIDTH) + transform.position.x;
-}
-
 bool transform_y_comparison(const Transform& lhs, const Transform& rhs) {
-    int lhs_abspixel {transform_abspixel(lhs)};
-    int rhs_abspixel {transform_abspixel(rhs)};
-    return lhs_abspixel < rhs_abspixel;
+    return lhs.position.y < rhs.position.y;
 }
 
 void Game::render() {

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -91,14 +91,16 @@ entt::entity Game::create_entity() {
 void Game::initialise(const std::vector<std::string>& tile_paths) {
     SDL_Init(SDL_INIT_EVERYTHING);
 
+    SDL_GetDesktopDisplayMode(0, &display_mode);
+
     // Create the SDL Window
     window = SDL_CreateWindow(
         NULL,                       // title - leave blank for now
-        SDL_WINDOWPOS_CENTERED,     // Window x position (centred)
+        SDL_WINDOWPOS_CENTERED,     // Window xconstant position (centred)
         SDL_WINDOWPOS_CENTERED,     // Window y position (centred)
-        constants::WINDOW_WIDTH,    // X res from constant
-        constants::WINDOW_HEIGHT,   // Y res from constant
-        SDL_WINDOW_INPUT_GRABBED    // Input grabbed flag
+        display_mode.w,             // X res from current display mode
+        display_mode.h,             // Y res from current display mode
+        SDL_WINDOW_FULLSCREEN       // Input grabbed flag
     );
 
     if (!window) {
@@ -125,6 +127,13 @@ void Game::initialise(const std::vector<std::string>& tile_paths) {
     SDL_QueryTexture(
         textures[15], NULL, NULL, &width_px, &height_px
     );
+
+    render_rect = {
+        20, 
+        20,
+        display_mode.w - 40,
+        display_mode.h - 40
+    };
 
     SDL_RenderSetClipRect(renderer, &render_rect);    
     // TODO: initialise ImGui

--- a/src/engine/game.h
+++ b/src/engine/game.h
@@ -4,6 +4,7 @@
 #include <SDL2/SDL.h>
 #include <entt/entt.hpp>
 #include <unordered_map>
+#include <memory>
 
 #include "components/transform.h"
 #include "components/sprite.h"
@@ -24,17 +25,18 @@ class Game {
     SDL_Window* window;
     SDL_DisplayMode display_mode;
 
-    // Investigate whether this should be default-initialised
-    Camera camera;
+    // Camera is smart pointer to allow late initialisation
+    std::unique_ptr<Camera> camera;
+
+    // TileMap and Mouse can be initialised during game construction
+    TileMap tilemap;
+    Mouse mouse;
 
     // Investigate whether this is redundant!
     SDL_Rect render_rect;
     
     // Todo: read re. asset stores
     std::unordered_map<int, SDL_Texture*> textures;
-
-    TileMap tilemap;
-    Mouse mouse;
 
     void load_textures(const std::vector<std::string>& tile_paths);
     void load_tilemap();

--- a/src/engine/game.h
+++ b/src/engine/game.h
@@ -22,12 +22,13 @@ class Game {
     entt::registry registry;
     SDL_Renderer* renderer;
     SDL_Window* window;
+    SDL_DisplayMode display_mode;
 
     // Investigate whether this should be default-initialised
     Camera camera;
 
     // Investigate whether this is redundant!
-    SDL_Rect render_rect{20, 20, constants::WINDOW_WIDTH-40, constants::WINDOW_HEIGHT-40};
+    SDL_Rect render_rect;
     
     // Todo: read re. asset stores
     std::unordered_map<int, SDL_Texture*> textures;


### PR DESCRIPTION
This change removes references to `window_width`/`window_height` constants.

Instead, width/height values are fetched from the desktop display mode.

This has meant updating the Camera type to accept the display mode as an input.

