### PR TITLE
Add Z-index

### DIFF
--- a/src/engine/components/sprite.h
+++ b/src/engine/components/sprite.h
@@ -20,10 +20,4 @@ struct Sprite {
         }
 };
 
-struct TerrainSprite: public Sprite {   
-};
-
-struct VerticalSprite: public Sprite {
-};
-
 #endif

--- a/src/engine/components/transform.h
+++ b/src/engine/components/transform.h
@@ -5,6 +5,7 @@
 
 struct Transform{
     glm::vec2 position;
+    int z_index;
     double rotation;
 };
 

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -66,8 +66,8 @@ void Game::load_tilemap() {
 
             entt::entity entity {tilemap.at(x, y)};
             
-            registry.emplace<Transform>(entity, position, 0.0);
-            registry.emplace<TerrainSprite>(entity, textures[texture_id]);
+            registry.emplace<Transform>(entity, position, 0, 0.0);
+            registry.emplace<Sprite>(entity, textures[texture_id]);
         }
     }
 }
@@ -173,8 +173,14 @@ void Game::update() {
     millis_previous_frame = SDL_GetTicks();
 }
 
-bool transform_y_comparison(const Transform& lhs, const Transform& rhs) {
-    return lhs.position.y < rhs.position.y;
+bool transform_comparison(const Transform& lhs, const Transform& rhs) {
+    if (
+        lhs.z_index < rhs.z_index ||
+        (lhs.z_index == rhs.z_index && lhs.position.y < rhs.position.y)
+    ) {
+        return true;
+    }
+    return false;
 }
 
 void Game::render() {
@@ -183,10 +189,9 @@ void Game::render() {
 
     const SDL_Rect& camera_position {camera->get_position()};
 
-    registry.sort<Transform>(transform_y_comparison);
+    registry.sort<Transform>(transform_comparison);
 
-    render_sprites<TerrainSprite>(registry, camera_position, renderer, render_rect, false);
-    render_sprites<VerticalSprite>(registry, camera_position, renderer, render_rect, debug_mode);
+    render_sprites(registry, camera_position, renderer, render_rect, debug_mode);
 
     if (debug_mode) {
         render_imgui_gui(renderer, registry, textures[15], mouse);

--- a/src/engine/game.h
+++ b/src/engine/game.h
@@ -73,6 +73,11 @@ class Game {
         void add_component(const entt::entity& entity, TArgs ...args) {
             registry.emplace<T>(entity, std::forward<TArgs>(args)...);
         }
+
+        template <typename T>
+        T get_component(const entt::entity& entity) {
+            return registry.get<T>(entity);
+        }
 };
 
 #endif

--- a/src/engine/systems/imgui_render.h
+++ b/src/engine/systems/imgui_render.h
@@ -62,8 +62,8 @@ void render_imgui_gui(
     if (ImGui::Button("Create sprite")) {
         spdlog::info("Creating a new entity!");
         entt::entity new_entity {registry.create()};
-        registry.emplace<Transform>(new_entity, position, 0.0f);
-        registry.emplace<VerticalSprite>(new_entity, sprite_texture);
+        registry.emplace<Transform>(new_entity, position, 1, 0.0f);
+        registry.emplace<Sprite>(new_entity, sprite_texture);
         registry.emplace<RigidBody>(new_entity, velocity);
     }
     

--- a/src/engine/systems/render.h
+++ b/src/engine/systems/render.h
@@ -42,13 +42,12 @@ void render_sprite(
         );
     }
 
-    if (render_bounding_box) {
+    if (render_bounding_box && transform.z_index != 0) {
         SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
         SDL_RenderDrawRect(renderer, &dest_rect);
     }
 }
 
-template <typename SpriteType>
 void render_sprites(
     entt::registry& registry, 
     const SDL_Rect& camera, 
@@ -56,11 +55,11 @@ void render_sprites(
     const SDL_Rect& render_clip_rect, 
     bool render_bounding_box
 ) {
-    auto sprites = registry.view<Transform, SpriteType>();
-    sprites.template use<Transform>();
+    auto sprites = registry.view<Transform, Sprite>();
+    sprites.use<Transform>();
     for (auto entity: sprites) {
-        const auto& transform {sprites.template get<Transform>(entity)};
-        const auto& sprite {sprites.template get<SpriteType>(entity)};
+        const auto& transform {sprites.get<Transform>(entity)};
+        const auto& sprite {sprites.get<Sprite>(entity)};
         render_sprite(renderer, camera, render_clip_rect, transform, sprite, render_bounding_box);
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,10 +32,18 @@ int main() {
 
     for (int n=0; n<3; n++) {
         entt::entity entity_1 {game.get_tilemap().at(n, 3)};
-        entt::entity entity_2 {game.get_tilemap().at(n, 1)};
+        Transform entity_1_transform {game.get_component<Transform>(entity_1)};
 
-        game.add_component<VerticalSprite>(entity_1, game.fetch_texture(n+4));
-        game.add_component<VerticalSprite>(entity_2, game.fetch_texture(n+4));
+        entt::entity entity_2 {game.get_tilemap().at(n, 1)};
+        Transform entity_2_transform {game.get_component<Transform>(entity_2)};
+
+        entt::entity new_entity {game.create_entity()};
+        game.add_component<Transform>(new_entity, entity_1_transform.position, 1, entity_2_transform.rotation);
+        game.add_component<Sprite>(new_entity, game.fetch_texture(n+4));
+
+        entt::entity new_entity_2 {game.create_entity()};
+        game.add_component<Transform>(new_entity_2, entity_2_transform.position, 1, entity_2_transform.rotation);
+        game.add_component<Sprite>(new_entity_2, game.fetch_texture(n+4));
     }
 
 


### PR DESCRIPTION
This commit introduces a z-index to the Transform component so that sprites can be rendered in the correct 'depth' order.

Specifically:

1. Transform component has been updated to include a z_index attribute
2. Logic used to sort transform components has been updated to consider the z_index attribute
3. Additional sprite types (terrain, vertical) used to implement sprite layering previously have been removed
4. Render logic has been updated to consider only the Sprite type (no longer considering Vertical, Terrain sprites)