### PR TITLE
34 use string keys for texture map

### DIFF
--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <filesystem>
 
 #include <glm/glm.hpp>
 #include <SDL2/SDL_image.h>
@@ -32,14 +33,17 @@ Game::~Game() {
     spdlog::info("Game destuctor called.");
 }
 
-void Game::load_textures(const std::vector<std::string>& tile_paths){
+void Game::load_textures(const std::string& directory){
 
-    for (unsigned int texture_id=0; texture_id<tile_paths.size(); texture_id++) {
-        SDL_Surface* surface {IMG_Load(tile_paths.at(texture_id).c_str())};
+    std::filesystem::path textures_dir{directory};
+
+    for (auto const& entry: std::filesystem::directory_iterator{textures_dir}) {
+
+        SDL_Surface* surface {IMG_Load(entry.path().c_str())};
         if (!surface) {
             spdlog::info(
-                "Could not load texture from path: " +
-                tile_paths.at(texture_id)
+                "Could not load texture from path: " + 
+                entry.path().string()
             );
         }
 
@@ -47,12 +51,12 @@ void Game::load_textures(const std::vector<std::string>& tile_paths){
         if (!texture) {
             spdlog::info(
                 "Could not load texture from surface using image: " +
-                tile_paths.at(texture_id)
+                entry.path().string()
             );
         }
 
         SDL_FreeSurface(surface);
-        textures.emplace(texture_id, texture);
+        textures.emplace(entry.path().filename().string(), texture);
     }
 }
 
@@ -62,12 +66,11 @@ void Game::load_tilemap() {
         for (int x=0; x<constants::MAP_SIZE_N_TILES; x++) {
 
             glm::ivec2 position {tilemap.grid_to_pixel(x, y)};
-            int texture_id {1};
 
             entt::entity entity {tilemap.at(x, y)};
             
             registry.emplace<Transform>(entity, position, 0, 0.0);
-            registry.emplace<Sprite>(entity, textures[texture_id]);
+            registry.emplace<Sprite>(entity, textures["green.png"]);
         }
     }
 }
@@ -76,7 +79,7 @@ entt::entity Game::create_entity() {
     return registry.create();
 }
 
-void Game::initialise(const std::vector<std::string>& tile_paths) {
+void Game::initialise(const std::string textures_path) {
     SDL_Init(SDL_INIT_EVERYTHING);
 
     SDL_GetDesktopDisplayMode(0, &display_mode);
@@ -107,7 +110,7 @@ void Game::initialise(const std::vector<std::string>& tile_paths) {
         spdlog::error("Could not initialise the SDL Renderer.");
     }
 
-    load_textures(tile_paths);
+    load_textures(textures_path);
     load_tilemap();
 
     render_rect = {20, 20, display_mode.w - 40, display_mode.h - 40};
@@ -194,7 +197,7 @@ void Game::render() {
     render_sprites(registry, camera_position, renderer, render_rect, debug_mode);
 
     if (debug_mode) {
-        render_imgui_gui(renderer, registry, textures[15], mouse);
+        render_imgui_gui(renderer, registry, textures["moveable_sprite_tall_test.png"], mouse);
     }
 
     SDL_RenderPresent(renderer);

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -197,7 +197,7 @@ void Game::render() {
     render_sprites(registry, camera_position, renderer, render_rect, debug_mode);
 
     if (debug_mode) {
-        render_imgui_gui(renderer, registry, textures["moveable_sprite_tall_test.png"], mouse);
+        render_imgui_gui(renderer, registry, textures, mouse);
     }
 
     SDL_RenderPresent(renderer);

--- a/src/engine/game.h
+++ b/src/engine/game.h
@@ -37,9 +37,9 @@ class Game {
     SDL_Rect render_rect;
     
     // Todo: read re. asset stores
-    std::unordered_map<int, SDL_Texture*> textures;
+    std::unordered_map<std::string, SDL_Texture*> textures;
 
-    void load_textures(const std::vector<std::string>& tile_paths);
+    void load_textures(const std::string& directory);
     void load_tilemap();
     void process_input();
     void update();
@@ -55,7 +55,7 @@ class Game {
         // TODO: define operator= method to enable -Weffc++
         // ...operator=(const Game&) ...;
 
-        void initialise(const std::vector<std::string>& tile_paths);
+        void initialise(const std::string textures_path);
         void run();
         void destroy();
 
@@ -63,7 +63,7 @@ class Game {
             return tilemap;
         }
 
-        SDL_Texture* const fetch_texture(int index) {
+        SDL_Texture* const fetch_texture(const std::string& index) {
             return textures[index];
         }
 

--- a/src/engine/systems/imgui_render.h
+++ b/src/engine/systems/imgui_render.h
@@ -59,21 +59,6 @@ void render_imgui_gui(
     // Velocity Y
     ImGui::InputInt("Y velocity", &velocity.y);
 
-    // if (ImGui::BeginCombo("combo 1", combo_preview_value, flags))
-    // {
-    //     for (int n = 0; n < IM_ARRAYSIZE(items); n++)
-    //     {
-    //         const bool is_selected = (item_selected_idx == n);
-    //         if (ImGui::Selectable(items[n], is_selected))
-    //             item_selected_idx = n;
-
-    //         // Set the initial focus when opening the combo (scrolling + keyboard navigation focus)
-    //         if (is_selected)
-    //             ImGui::SetItemDefaultFocus();
-    //     }
-    //     ImGui::EndCombo();
-    // }
-
     static std::string selected_sprite_texture{"moveable_sprite_tall_test.png"};
 
     if(ImGui::BeginCombo("Sprite image", selected_sprite_texture.c_str())) {

--- a/src/engine/systems/imgui_render.h
+++ b/src/engine/systems/imgui_render.h
@@ -18,14 +18,9 @@
 void render_imgui_gui(
     SDL_Renderer* renderer,
     entt::registry& registry,
-    SDL_Texture* sprite_texture,
+    const std::unordered_map<std::string, SDL_Texture*>& textures,
     const Mouse& mouse
 ) {
-    // bool show_demo_window {true};
-
-    static glm::ivec2 position;
-    static glm::ivec2 velocity;
-
     ImGui_ImplSDLRenderer2_NewFrame();
     ImGui_ImplSDL2_NewFrame();
     ImGui::NewFrame();
@@ -47,6 +42,11 @@ void render_imgui_gui(
         std::to_string(grid_position.y).c_str()
     );
 
+    // bool show_demo_window {true};
+
+    static glm::ivec2 position;
+    static glm::ivec2 velocity;    
+
     // Input for X
     ImGui::InputInt("X postion", &position.x);
 
@@ -59,11 +59,44 @@ void render_imgui_gui(
     // Velocity Y
     ImGui::InputInt("Y velocity", &velocity.y);
 
+    // if (ImGui::BeginCombo("combo 1", combo_preview_value, flags))
+    // {
+    //     for (int n = 0; n < IM_ARRAYSIZE(items); n++)
+    //     {
+    //         const bool is_selected = (item_selected_idx == n);
+    //         if (ImGui::Selectable(items[n], is_selected))
+    //             item_selected_idx = n;
+
+    //         // Set the initial focus when opening the combo (scrolling + keyboard navigation focus)
+    //         if (is_selected)
+    //             ImGui::SetItemDefaultFocus();
+    //     }
+    //     ImGui::EndCombo();
+    // }
+
+    static std::string selected_sprite_texture{"moveable_sprite_tall_test.png"};
+
+    if(ImGui::BeginCombo("Sprite image", selected_sprite_texture.c_str())) {
+        for (std::pair<std::string, SDL_Texture*> item: textures)
+        {
+            const bool is_selected = (selected_sprite_texture == item.first);
+
+            if (ImGui::Selectable(item.first.c_str(), is_selected)) {
+                selected_sprite_texture = item.first;
+            };
+
+            // Set the initial focus when opening the combo (scrolling + keyboard navigation focus)
+            if (is_selected)
+                ImGui::SetItemDefaultFocus();
+        }
+        ImGui::EndCombo();
+    }
+
     if (ImGui::Button("Create sprite")) {
         spdlog::info("Creating a new entity!");
         entt::entity new_entity {registry.create()};
         registry.emplace<Transform>(new_entity, position, 1, 0.0f);
-        registry.emplace<Sprite>(new_entity, sprite_texture);
+        registry.emplace<Sprite>(new_entity, textures.at(selected_sprite_texture));
         registry.emplace<RigidBody>(new_entity, velocity);
     }
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,28 +9,13 @@
 int main() {
     Game game;
 
-    std::vector<std::string> tile_paths {
-        "./assets/road.png",                        // 0
-        "./assets/green.png",                       // 1
-        "./assets/blue.png",                        // 2
-        "./assets/pink.png",                        // 3
-        "./assets/tallest_tile.png",                // 4
-        "./assets/tall_tile.png",                   // 5
-        "./assets/taller_tile.png",                 // 6
-        "./assets/BLBR.png",                        // 7
-        "./assets/BLTL.png",                        // 8
-        "./assets/BLTR.png",                        // 9
-        "./assets/BRTR.png",                        // 10
-        "./assets/TLBR.png",                        // 11
-        "./assets/TLTR.png",                        // 12
-        "./assets/BLBRTR.png",                      // 13
-        "./assets/moveable_sprite_test.png",        // 14
-        "./assets/moveable_sprite_tall_test.png",   // 15
-    };
-
-    game.initialise(tile_paths);
+    game.initialise("/home/marv/Documents/Projects/isometric-game/assets/");
 
     for (int n=0; n<3; n++) {
+        std::vector<std::string> building_textures {
+            "tall_tile.png", "taller_tile.png", "tallest_tile.png"
+        };
+
         entt::entity entity_1 {game.get_tilemap().at(n, 3)};
         Transform entity_1_transform {game.get_component<Transform>(entity_1)};
 
@@ -39,11 +24,11 @@ int main() {
 
         entt::entity new_entity {game.create_entity()};
         game.add_component<Transform>(new_entity, entity_1_transform.position, 1, entity_2_transform.rotation);
-        game.add_component<Sprite>(new_entity, game.fetch_texture(n+4));
+        game.add_component<Sprite>(new_entity, game.fetch_texture(building_textures[n]));
 
         entt::entity new_entity_2 {game.create_entity()};
         game.add_component<Transform>(new_entity_2, entity_2_transform.position, 1, entity_2_transform.rotation);
-        game.add_component<Sprite>(new_entity_2, game.fetch_texture(n+4));
+        game.add_component<Sprite>(new_entity_2, game.fetch_texture(building_textures[n]));
     }
 
 


### PR DESCRIPTION
This PR is comprised of the changes necessary to change the way that texture assets are loaded into/reference in the game engine, such that:

1. Textures are given a string index (their file name) in place of the previous numeric index
2. Textures are automatically loaded from a target directory, instead of filepath values hardcoded into the engine

The PR enables the selection of sprite texture index (filename) when creating new sprites in the IMGUI debug UI