### PR TITLE
38 make changes necessary to mitigate stuttering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.10)
 
 project(isometric-game LANGUAGES CXX)
 
+# set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg")
+# set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pg")
+# set( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -pg")
+
 link_libraries(SDL2 SDL2_image spdlog fmt)
 
 include_directories(

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # isometric-game
 A two-dimensional, isometric projection game project inspired by the 2D Game Engine with C++ course on Pikuma.com
+
+### Development notes
+
+#### GLM types
+
+| Variable | Description | Type | Reason |
+|----------|-------------|------|--------|
+|Camera::mouse_screen_position|Capture the pixel coordinate of the mouse relative to the screen|ivec2|Pixels are whole numbers|
+|Tilemap::grid_to_pixel()|Get the pixel coordinate of the origin (e.g. top left) of a specified (x, y) tile in the tilemap relative to the world space|ivec2|Pixels are whole numbers|
+|Mouse::window_previous_position / window_current_position / world_position / grid_position|Capture the current and previous mouse position (pixel) relative to the window; capture the mouse pixel position relative to the world; capture the mouse position relative to the tilemap|ivec2|Pixel and grid coordinates consist of whole numbers|
+|MouseMap::pixel_colour_vector() / tile_walk() / pixel_to_grid()|Get the mouse position relative to the tilemap by comparing the current mouse position to the "first" tile position, and to the mousemap|ivec2|All of the relevant coordinate values are comprised of whole numbers|
+|RigidBody::velocity|The velocity of a rigid body|**vec2**|Velocity is applied over time intervals (millis per frame) with fractional portions|
+|Sprite::offset|An offset dictating where a sprite should be rendered relative to a transform position|**vec2**|**Not sure!** - potentially because __Transform::position__ is a vec2, and addition between a ivec2 and a vec2 is not supported|
+|Transform::position|The position of an entity in world space|**vec2**|Transforms are updated over time intervals (millis per frame) with fractional portions|
+
+

--- a/src/engine/components/sprite.h
+++ b/src/engine/components/sprite.h
@@ -2,6 +2,7 @@
 #define SPRITECOMPONENT_H
 
 #include <SDL2/SDL.h>
+#include <glm/glm.hpp>
 
 #include "constants.h"
 
@@ -9,14 +10,11 @@ struct Sprite {
     SDL_Texture* texture;
     int height_px;
     int width_px;
-    int vertical_offset_px;
-    int horizontal_offset_px;
+    glm::vec2 offset;
     Sprite(SDL_Texture* texture):
         texture{texture} {
             SDL_QueryTexture(texture, NULL, NULL, &width_px, &height_px);
-            vertical_offset_px = constants::TILE_HEIGHT - height_px;
-            horizontal_offset_px = 0;
-            // horizontal_offset_px = constants::TILE_WIDTH - width_px;
+            offset = {0, constants::TILE_HEIGHT - height_px};
         }
 };
 

--- a/src/engine/constants.h
+++ b/src/engine/constants.h
@@ -3,7 +3,7 @@
 
 namespace constants {
     inline constexpr int FPS                    {60};
-    inline constexpr int MILLIS_PER_FRAME       {1'000/FPS};
+    inline constexpr float MILLIS_PER_FRAME     {1'000.f/FPS};
     inline constexpr int WINDOW_HEIGHT          {768};
     inline constexpr int WINDOW_WIDTH           {1024};
 

--- a/src/engine/game.h
+++ b/src/engine/game.h
@@ -19,6 +19,7 @@ class Game {
 
     // Has to be default initialised because it's referenced in Game::update()
     int millis_previous_frame{};    
+    uint64_t _last_time{0};
 
     entt::registry registry;
     SDL_Renderer* renderer;

--- a/src/engine/systems/imgui_render.h
+++ b/src/engine/systems/imgui_render.h
@@ -44,20 +44,20 @@ void render_imgui_gui(
 
     // bool show_demo_window {true};
 
-    static glm::ivec2 position;
-    static glm::ivec2 velocity;    
+    static glm::vec2 position;
+    static glm::vec2 velocity;    
 
     // Input for X
-    ImGui::InputInt("X postion", &position.x);
+    ImGui::InputFloat("X postion", &position.x);
 
     // Input for Y
-    ImGui::InputInt("Y position", &position.y);
+    ImGui::InputFloat("Y position", &position.y);
 
     // Velocity X
-    ImGui::InputInt("X velocity", &velocity.x);
+    ImGui::InputFloat("X velocity", &velocity.x);
 
     // Velocity Y
-    ImGui::InputInt("Y velocity", &velocity.y);
+    ImGui::InputFloat("Y velocity", &velocity.y);
 
     static std::string selected_sprite_texture{"moveable_sprite_tall_test.png"};
 

--- a/src/engine/systems/movement.h
+++ b/src/engine/systems/movement.h
@@ -17,23 +17,14 @@ bool is_out_of_bounds(const Transform& transform, const MouseMap& mousemap) {
     );
 }
 
-void apply_velocity(
-    Transform& transform, 
-    const RigidBody& rigid_body, 
-    const double delta_time
-) {
-    transform.position.x += (rigid_body.velocity.x * delta_time);
-    transform.position.y += (rigid_body.velocity.y * delta_time);
-}
-
-void movement_update(entt::registry& registry, const MouseMap& mousemap, const double delta_time) {
+void movement_update(entt::registry& registry, const MouseMap& mousemap, const float delta_time) {
     auto entities_in_motion {registry.view<RigidBody, Transform>()};
     for (auto entity: entities_in_motion) {
         Transform& transform {entities_in_motion.get<Transform>(entity)};
         const RigidBody& rigid_body {entities_in_motion.get<RigidBody>(entity)};
 
         if (!is_out_of_bounds(transform, mousemap)) {
-            apply_velocity(transform, rigid_body, delta_time);
+            transform.position += rigid_body.velocity * delta_time;
         } else {
             registry.destroy(entity);
         }


### PR DESCRIPTION
The summary of changes is:

1. Update the timestep to be more explicit in what's happening - change is likely beneficial, even if only from the perspective of the clarity of the comments
2. Sprite, movement and render code have been updated to enable certain calculations (e.g. world/camera offset, velocity/delta time) to me made using binary operators on GLM types - adding/subtracting GLM vectors as opposed to adding/subtracting vector X, Y coordinates separately
3. Render code has been updated to use RenderCopyExF (floating point) instead of integer-equivalents
4. Render code no longer does the render rect intersection calculation - perhaps that's not necessary in either case

None of these changes actually fixed the stuttering, so the issue should remain open - however I don't want to let the stuttering issue (a frustrating one) keep me from doing some of the other fun stuff (like pathfinding).