### PR TITLE
40 create direction enumeration

### DIFF
--- a/src/engine/constants.h
+++ b/src/engine/constants.h
@@ -26,12 +26,6 @@ namespace constants {
     inline constexpr int TILEMAP_Y_START        {MAP_BORDER_PX};
     inline constexpr int CAMERA_BORDER_PX       {80};
 
-    inline constexpr glm::ivec2 _no_direction   {0, 0}; 
-    inline constexpr glm::ivec2 _left           {-1, 0};
-    inline constexpr glm::ivec2 _up             {0, -1};
-    inline constexpr glm::ivec2 _right          {1, 0};
-    inline constexpr glm::ivec2 _down           {0, 1};
-
     enum Directions {
         NO_DIRECTION,
         LEFT,

--- a/src/engine/constants.h
+++ b/src/engine/constants.h
@@ -1,6 +1,8 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
+#include <glm/glm.hpp>
+
 namespace constants {
     inline constexpr int FPS                    {60};
     inline constexpr float MILLIS_PER_FRAME     {1'000.f/FPS};
@@ -23,6 +25,24 @@ namespace constants {
     inline constexpr int TILEMAP_X_START        {(RENDER_SPACE_WIDTH_PX / 2) - (TILE_WIDTH / 2)};
     inline constexpr int TILEMAP_Y_START        {MAP_BORDER_PX};
     inline constexpr int CAMERA_BORDER_PX       {80};
+
+    inline constexpr glm::ivec2 _no_direction   {0, 0}; 
+    inline constexpr glm::ivec2 _left           {-1, 0};
+    inline constexpr glm::ivec2 _up             {0, -1};
+    inline constexpr glm::ivec2 _right          {1, 0};
+    inline constexpr glm::ivec2 _down           {0, 1};
+
+    enum Directions {
+        NO_DIRECTION,
+        LEFT,
+        UP,
+        RIGHT,
+        DOWN
+    };
+
+    inline constexpr glm::ivec2 directions[5] {
+        _no_direction, _left, _up, _right, _down
+    };
 }
 
 #endif

--- a/src/engine/constants.h
+++ b/src/engine/constants.h
@@ -41,7 +41,11 @@ namespace constants {
     };
 
     inline constexpr glm::ivec2 directions[5] {
-        _no_direction, _left, _up, _right, _down
+        glm::ivec2{0, 0},                       // NO_DIRECTION
+        glm::ivec2{-1, 0},                      // LEFT
+        glm::ivec2{0, -1},                      // UP
+        glm::ivec2{1, 0},                       // RIGHT
+        glm::ivec2{0, 1}                        // DOWN
     };
 }
 

--- a/src/engine/mousemap.cpp
+++ b/src/engine/mousemap.cpp
@@ -49,26 +49,26 @@ SDL_Color MouseMap::mousemap_pixel_colour(const glm::ivec2& pixel_offset) const 
 glm::ivec2 MouseMap::pixel_colour_vector(const SDL_Colour& colour) const {
 
     if (colour.r == 255 && colour.g == 255 && colour.b == 255) {
-        return glm::ivec2{0, 0};
+        return constants::directions[constants::NO_DIRECTION];
     }
 
     if (colour.r == 255) {
-        return glm::ivec2{-1, 0};
+        return constants::directions[constants::LEFT];
     }
 
     if (colour.g == 255) {
-        return glm::ivec2{0, -1};
+        return constants::directions[constants::UP];
     }
 
     if (colour.b == 255) {
-        return glm::ivec2{1, 0};
+        return constants::directions[constants::RIGHT];
     }
 
     if (colour.r == 0 && colour.g == 0 && colour.b == 0) {
-        return glm::ivec2{0, 1};
+        return constants::directions[constants::DOWN];
     }
 
-    return glm::ivec2{0, 0};
+    return constants::directions[constants::NO_DIRECTION];
 }
 
 // Calculate the 'coarse' grid position tile walk map


### PR DESCRIPTION
Updated constants to create an enumeration with direction values and an associated array containing related vectors (glm::ivec2).

MouseMap logic previously creating these directions "by hand" has been updated.