### PR TITLE
Set const for SpriteSheet/Sprite members

### DIFF
--- a/src/engine/components/sprite.h
+++ b/src/engine/components/sprite.h
@@ -9,12 +9,12 @@
 struct Sprite {
     // to be replaced with an asset identifier?
     SDL_Texture* texture;
-    SDL_Rect& source_rect;
-    glm::vec2 offset;
+    const SDL_Rect& source_rect;
+    const glm::vec2 offset;
 
     Sprite(
         SDL_Texture* texture,
-        SDL_Rect& source_rect
+        const SDL_Rect& source_rect
     ): 
         texture{texture}, 
         source_rect{source_rect},

--- a/src/engine/spritesheet.cpp
+++ b/src/engine/spritesheet.cpp
@@ -75,10 +75,10 @@ SpriteSheet::~SpriteSheet() {
     SDL_DestroyTexture(spritesheet);
 }
 
-SDL_Rect& SpriteSheet::get_sprite_rect(const std::string& sprite_name) {
+const SDL_Rect& SpriteSheet::get_sprite_rect(const std::string& sprite_name) const {
     return sprites.at(sprite_name);
 }
 
-SDL_Texture* SpriteSheet::get_spritesheet_texture() {
+SDL_Texture* SpriteSheet::get_spritesheet_texture() const {
     return spritesheet;
 }

--- a/src/engine/spritesheet.h
+++ b/src/engine/spritesheet.h
@@ -7,11 +7,11 @@
 
 
 class SpriteSheet {
-    std::string image_path;
-    std::string atlas_path;
+    const std::string image_path;
+    const std::string atlas_path;
 
     /* TODO: the attributes perhaps should be private! */
-    std::unordered_map<std::string, SDL_Rect> sprites;
+    std::unordered_map<std::string, const SDL_Rect> sprites;
     SDL_Texture* spritesheet;
 
     public:
@@ -20,8 +20,8 @@ class SpriteSheet {
         ~SpriteSheet();
         
         // Not yet implemented/used
-        SDL_Rect& get_sprite_rect(const std::string& sprite_name);
-        SDL_Texture* get_spritesheet_texture();
+        const SDL_Rect& get_sprite_rect(const std::string& sprite_name) const;
+        SDL_Texture* get_spritesheet_texture() const;
 };
 
 #endif


### PR DESCRIPTION
Adds `const` qualifiers to `SpriteSheet` and `Sprite` members where's it's appropriate.

Can't do it for the `SDL_Texture*` because a downstream SDL function (`SDL_RenderCopyExF`) won't accept a non-mutable `SDL_Texture*`.