### PR TITLE
53 implement tilemap in single vector

### DIFF
--- a/src/engine/tilemap.cpp
+++ b/src/engine/tilemap.cpp
@@ -14,12 +14,8 @@ TileMap::TileMap(entt::registry& registry) {
     spdlog::info("TileMap constructor called.");
 
     // Create the entities associated with the map
-    for (int x=0; x<constants::MAP_SIZE_N_TILES; x++) {
-        std::vector<entt::entity> row;
-        for (int y=0; y<constants::MAP_SIZE_N_TILES; y++) {
-            row.push_back(registry.create());
-        }
-        tilemap.push_back(row);
+    for (int cell=0; cell<pow(constants::MAP_SIZE_N_TILES, 2); cell++) {
+        tilemap.emplace_back(registry.create());
     }
 }
 
@@ -30,7 +26,7 @@ TileMap::~TileMap() {
 
 // Get an entity from tilemap position x, y
 entt::entity TileMap::at(const int x, const int y) const {
-    return tilemap.at(x).at(y);
+    return tilemap.at((y * constants::MAP_SIZE_N_TILES) + x);
 }
 
 // Public function converting x, y tilemap coordinates to screen coordinates

--- a/src/engine/tilemap.h
+++ b/src/engine/tilemap.h
@@ -6,7 +6,7 @@
 #include <glm/glm.hpp>
 
 class TileMap {
-    std::vector<std::vector<entt::entity>> tilemap;
+    std::vector<entt::entity> tilemap;
     
     public:
         TileMap(entt::registry& registry);


### PR DESCRIPTION
Re-implements the tilemap as a single vector instead of a vector of vectors.

Getting a value from the vector using x, y coordinates is as simple as:

1. Getting the length of a tilemap row (e.g. constants::MAP_SIZE_N_TILES)
2. Multiplying the y coordinate value by the tilemap row length
3. Adding the x coordinate value

e.g., if constants::MAP_SIZE_N_TILES is 4 (e.g. 16 tile grid), and when retrieving entity at position 2, 3:

 - Length of row: **4**
 - Y (3) * row length (4) = 12
 - 12 + X (2) = 14
 - Value at grid 2, 3 is in tilemap[14]