### PR TITLE
52 highlight the currently selected tile in debug mode

### DIFF
--- a/src/engine/camera.cpp
+++ b/src/engine/camera.cpp
@@ -2,7 +2,7 @@
 #include "constants.h"
 #include <SDL2/SDL.h>
 
-Camera::Camera(const SDL_DisplayMode& display_mode): camera_position {
+Camera::Camera(const SDL_DisplayMode& display_mode): camera_area {
     (constants::RENDER_SPACE_SIZE_PX.x / 2) - (display_mode.w / 2),             // Initial X
     0,                                                                          // Initial Y
     display_mode.w,                                                             // Width
@@ -21,36 +21,36 @@ void Camera::update(
     // Move left
     if (
         mouse_screen_position.x < constants::CAMERA_BORDER_PX &&
-        camera_position.x > 0
+        camera_area.x > 0
     ) {
-        camera_position.x -= 4;
+        camera_area.x -= 4;
     }
 
     // Move right
     if (
         (display_mode.w - mouse_screen_position.x) < constants::CAMERA_BORDER_PX &&
-        (camera_position.x + camera_position.w) < constants::RENDER_SPACE_SIZE_PX.x
+        (camera_area.x + camera_area.w) < constants::RENDER_SPACE_SIZE_PX.x
     ) {
-        camera_position.x += 4;
+        camera_area.x += 4;
     }
 
     // Move up
     if (
         mouse_screen_position.y < constants::CAMERA_BORDER_PX &&
-        camera_position.y > 0
+        camera_area.y > 0
     ) {
-        camera_position.y -= 4;
+        camera_area.y -= 4;
     }
 
     // Move down
     if (
         (display_mode.h - mouse_screen_position.y) < constants::CAMERA_BORDER_PX &&
-        (camera_position.y + camera_position.h) < constants::RENDER_SPACE_SIZE_PX.y
+        (camera_area.y + camera_area.h) < constants::RENDER_SPACE_SIZE_PX.y
     ) {
-        camera_position.y += 4;
+        camera_area.y += 4;
     }
 }
 
-const SDL_Rect& Camera::get_position() const {
-    return camera_position;
+const glm::ivec2 Camera::get_position() const {
+    return glm::ivec2{camera_area.x, camera_area.y};
 }

--- a/src/engine/camera.h
+++ b/src/engine/camera.h
@@ -6,14 +6,14 @@
 #include "constants.h"
 
 class Camera {
-    SDL_Rect camera_position;
+    SDL_Rect camera_area;
 
     public:
         Camera(const SDL_DisplayMode& display_mode);
         ~Camera() = default;
 
         void update(const SDL_DisplayMode& display_mode, const glm::ivec2& mouse_screen_position);
-        const SDL_Rect& get_position() const;
+        const glm::ivec2 get_position() const;
 };
 
 #endif

--- a/src/engine/components/sprite.h
+++ b/src/engine/components/sprite.h
@@ -18,8 +18,15 @@ struct Sprite {
     ): 
         texture{texture}, 
         source_rect{source_rect},
+        /* 
+            TODO: determine how the offset should work.
+
+            Here, we basically determine that the BOTTOM MIDDLE of the portion
+            of the texture we're rendering should be aligned to the BOTTOM MIDDLE
+            of the tile we're rendering it into.
+        */
         offset{
-            constants::TILE_SIZE.x - source_rect.w, 
+            (constants::TILE_SIZE.x - source_rect.w) / 2, 
             constants::TILE_SIZE.y - source_rect.h
         } {}
 };

--- a/src/engine/components/sprite.h
+++ b/src/engine/components/sprite.h
@@ -24,9 +24,21 @@ struct Sprite {
             Here, we basically determine that the BOTTOM MIDDLE of the portion
             of the texture we're rendering should be aligned to the BOTTOM MIDDLE
             of the tile we're rendering it into.
+
+            NOTE that the "middle" is offset to the right, for a positive difference
+            (e.g. where the spite is smaller than a standard tile) in the case that 
+            the width of the source rect is not evenly divisible by two.
+
+            The logic used to do the offset (ceil division) will potentially have
+            the inverse affect in the case it's used when the sprite is larger than
+            a standard tile.
+
+            Will leave for now since we don't have any scenarios where that's the
+            case.
         */
         offset{
-            (constants::TILE_SIZE.x - source_rect.w) / 2, 
+            ((constants::TILE_SIZE.x - source_rect.w) / 2)
+            + ((constants::TILE_SIZE.x - source_rect.w) % 2 != 0),
             constants::TILE_SIZE.y - source_rect.h
         } {}
 };

--- a/src/engine/constants.h
+++ b/src/engine/constants.h
@@ -34,26 +34,28 @@ namespace constants {
         accounting for how tall the tiles are.
     */
     inline constexpr int MIN_TILE_DEPTH                 {33};
+    inline constexpr int MAX_TILE_DEPTH                 {34};
+    inline constexpr int GROUND_FLOOR_BUILDING_OFFSET   {77};
     inline constexpr glm::ivec2 OFFSET_TILEMAP_START    {TILEMAP_START - glm::ivec2{0, MIN_TILE_DEPTH}};
 
     inline constexpr int CAMERA_BORDER_PX               {80};
 
-    const std::string map_tile_png_path {
+    const std::string MAP_TILE_PNG_PATH {
         "/home/marv/Documents/Projects/isometric-game/assets/"
         "kenney_isometric-city/Spritesheet/cityTiles_sheet.png"
     };
 
-    const std::string map_atlas_path {
+    const std::string MAP_ATLAS_PATH {
         "/home/marv/Documents/Projects/isometric-game/assets/"
         "kenney_isometric-city/Spritesheet/cityTiles_sheet.xml"
     };
 
-    const std::string building_tile_png_path {
+    const std::string BUILDING_TILE_PNG_PATH {
         "/home/marv/Documents/Projects/isometric-game/assets/"
         "kenney_isometric-buildings-1/Spritesheet/buildingTiles_sheet.png"
     };
 
-    const std::string building_atlas_path {
+    const std::string BUILDING_ATLAS_PATH {
         "/home/marv/Documents/Projects/isometric-game/assets/"
         "kenney_isometric-buildings-1/Spritesheet/buildingTiles_sheet.xml"
     };
@@ -66,7 +68,7 @@ namespace constants {
         DOWN
     };
 
-    inline constexpr glm::ivec2 directions[5] {
+    inline constexpr glm::ivec2 DIRECTIONS[5] {
         glm::ivec2{0, 0},                       // NO_DIRECTION
         glm::ivec2{-1, 0},                      // LEFT
         glm::ivec2{0, -1},                      // UP
@@ -85,7 +87,7 @@ namespace constants {
         BOTTOM_RIGHT,
     };
 
-    constexpr std::array<glm::ivec2, 8> points_on_tile = [](){
+    constexpr std::array<glm::ivec2, 8> POINTS_ON_TILE = [](){
         int count{};
         std::array<glm::ivec2, 8> points = {};
 
@@ -106,12 +108,12 @@ namespace constants {
         return points;
     }();
 
-    constexpr std::array<glm::ivec2, 5> tile_edge_points {
-        points_on_tile[constants::TOP_MIDDLE],
-        points_on_tile[constants::RIGHT_MIDDLE],
-        points_on_tile[constants::BOTTOM_MIDDLE],
-        points_on_tile[constants::LEFT_MIDDLE],
-        points_on_tile[constants::TOP_MIDDLE]
+    constexpr std::array<glm::ivec2, 5> TILE_EDGE_POINTS {
+        POINTS_ON_TILE[constants::TOP_MIDDLE],
+        POINTS_ON_TILE[constants::RIGHT_MIDDLE],
+        POINTS_ON_TILE[constants::BOTTOM_MIDDLE],
+        POINTS_ON_TILE[constants::LEFT_MIDDLE],
+        POINTS_ON_TILE[constants::TOP_MIDDLE]
     };
 }
 

--- a/src/engine/constants.h
+++ b/src/engine/constants.h
@@ -2,7 +2,10 @@
 #define CONSTANTS_H
 
 #include <string>
+#include <vector>
+#include <array>
 
+#include <SDL2/SDL.h>
 #include <glm/glm.hpp>
 
 namespace constants {
@@ -69,6 +72,46 @@ namespace constants {
         glm::ivec2{0, -1},                      // UP
         glm::ivec2{1, 0},                       // RIGHT
         glm::ivec2{0, 1}                        // DOWN
+    };
+
+    enum PointsOnTile {
+        TOP_LEFT,
+        LEFT_MIDDLE,
+        BOTTOM_LEFT,
+        TOP_MIDDLE,
+        BOTTOM_MIDDLE,
+        TOP_RIGHT,
+        RIGHT_MIDDLE,
+        BOTTOM_RIGHT,
+    };
+
+    constexpr std::array<glm::ivec2, 8> points_on_tile = [](){
+        int count{};
+        std::array<glm::ivec2, 8> points = {};
+
+        for (int x=0; x<3; x++) {
+            for (int y=0; y<3; y++) {
+
+                if (x == 1 && y == 1) {
+                    continue;
+                }
+
+                points[count] = glm::ivec2{
+                    constants::TILE_SIZE_HALF * glm::ivec2{x, y}
+                };
+
+                count++;
+            }
+        }
+        return points;
+    }();
+
+    constexpr std::array<glm::ivec2, 5> tile_edge_points {
+        points_on_tile[constants::TOP_MIDDLE],
+        points_on_tile[constants::RIGHT_MIDDLE],
+        points_on_tile[constants::BOTTOM_MIDDLE],
+        points_on_tile[constants::LEFT_MIDDLE],
+        points_on_tile[constants::TOP_MIDDLE]
     };
 }
 

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -67,21 +67,66 @@ void Game::load_tilemap() {
 
             std::string tilepng;
 
-            if (x == 8 && y == 1) {
-                tilepng = "cityTiles_119.png";
+            if (x == 8 && y == 0) {
+                registry.emplace<Sprite>(
+                    entity, 
+                    building_tiles->get_spritesheet_texture(),
+                    building_tiles->get_sprite_rect("buildingTiles_014.png")
+                );
             } else if (y==1) {
-                tilepng = "cityTiles_036.png";
+                registry.emplace<Sprite>(
+                    entity, 
+                    city_tiles->get_spritesheet_texture(),
+                    city_tiles->get_sprite_rect("cityTiles_036.png")
+                );
             } else {
-                tilepng = "cityTiles_072.png";
+                registry.emplace<Sprite>(
+                    entity, 
+                    city_tiles->get_spritesheet_texture(),
+                    city_tiles->get_sprite_rect("cityTiles_072.png")
+                );
             }
-
-            registry.emplace<Sprite>(
-                entity, 
-                city_tiles->get_spritesheet_texture(),
-                city_tiles->get_sprite_rect(tilepng)
-            );
         }
     }
+
+    entt::entity building_level {registry.create()};
+    glm::ivec2 building_level_position {tilemap.grid_to_pixel({8, 0})};
+    building_level_position -= glm::ivec2{-1, (constants::MIN_TILE_DEPTH * 2) + 11};
+    registry.emplace<Transform>(
+        building_level, building_level_position, 1, 0.0
+    );
+
+    registry.emplace<Sprite>(
+        building_level, 
+        building_tiles->get_spritesheet_texture(),
+        building_tiles->get_sprite_rect("buildingTiles_043.png")
+    );
+
+    entt::entity second_building_level {registry.create()};
+    glm::ivec2 second_building_level_position {tilemap.grid_to_pixel({8, 0})};
+    second_building_level_position -= glm::ivec2{-1, (constants::MIN_TILE_DEPTH * 3) + 13};
+    registry.emplace<Transform>(
+        second_building_level, second_building_level_position, 2, 0.0
+    );
+
+    registry.emplace<Sprite>(
+        second_building_level, 
+        building_tiles->get_spritesheet_texture(),
+        building_tiles->get_sprite_rect("buildingTiles_043.png")
+    );
+
+    entt::entity final_building_level {registry.create()};
+    glm::ivec2 final_building_level_position {tilemap.grid_to_pixel({8, 0})};
+    final_building_level_position -= glm::ivec2{-1, (constants::MIN_TILE_DEPTH * 4) + 11};
+    registry.emplace<Transform>(
+        final_building_level, final_building_level_position, 3, 0.0
+    );
+
+    registry.emplace<Sprite>(
+        final_building_level, 
+        building_tiles->get_spritesheet_texture(),
+        building_tiles->get_sprite_rect("buildingTiles_058.png")
+    );
 }
 
 entt::entity Game::create_entity() {

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -59,7 +59,7 @@ void Game::load_tilemap() {
     for (int y=0; y<constants::MAP_SIZE_N_TILES; y++) {
         for (int x=0; x<constants::MAP_SIZE_N_TILES; x++) {
 
-            glm::ivec2 position {tilemap.grid_to_pixel(x, y)};
+            glm::ivec2 position {tilemap.grid_to_pixel({x, y})};
 
             entt::entity entity {tilemap.at(x, y)};
             
@@ -189,6 +189,49 @@ void Game::render() {
     // TODO: Update
     if (debug_mode) {
         render_imgui_gui(renderer, registry, mouse);
+
+        if (mouse.is_on_world_grid()) {
+            glm::ivec2 start_point {
+                tilemap.grid_to_pixel(mouse.get_grid_position())
+            };
+
+            start_point.x -= camera_position.x;
+            start_point.y -= (camera_position.y + constants::MIN_TILE_DEPTH);
+
+            SDL_Point my_points[] = {
+                SDL_Point{
+                    start_point.x, start_point.y + constants::TILE_SIZE_HALF.y
+                },
+                SDL_Point{
+                    start_point.x + constants::TILE_SIZE_HALF.x, 
+                    start_point.y
+                },
+                SDL_Point{
+                    start_point.x + constants::TILE_SIZE.x, 
+                    start_point.y + constants::TILE_SIZE_HALF.y
+                },
+                SDL_Point{
+                    start_point.x + constants::TILE_SIZE_HALF.x, 
+                    start_point.y + constants::TILE_SIZE.y
+                },
+                SDL_Point{
+                    start_point.x,
+                    start_point.y + constants::TILE_SIZE_HALF.y
+                }
+            };
+        
+            SDL_SetRenderDrawColor(
+                renderer,
+                255, 0, 0, 255
+            ); 
+        
+            SDL_RenderDrawLines(
+                renderer,
+                &my_points[0],
+                5
+                // sizeof(my_points)
+            );
+        }
     }
 
     SDL_RenderPresent(renderer);

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -44,11 +44,11 @@ void Game::load_spritesheets() {
     spdlog::info("Loading spritesheets");
 
     city_tiles.emplace(
-        constants::map_tile_png_path, constants::map_atlas_path, renderer
+        constants::MAP_TILE_PNG_PATH, constants::MAP_ATLAS_PATH, renderer
     );
 
     building_tiles.emplace(
-        constants::building_tile_png_path, constants::building_atlas_path, renderer
+        constants::BUILDING_TILE_PNG_PATH, constants::BUILDING_ATLAS_PATH, renderer
     );
 
     spdlog::info("Sprites loaded");
@@ -91,7 +91,7 @@ void Game::load_tilemap() {
 
     entt::entity building_level {registry.create()};
     glm::ivec2 building_level_position {tilemap.grid_to_pixel({8, 0})};
-    building_level_position -= glm::ivec2{-1, (constants::MIN_TILE_DEPTH * 2) + 11};
+    building_level_position -= glm::ivec2{0, constants::GROUND_FLOOR_BUILDING_OFFSET};
     registry.emplace<Transform>(
         building_level, building_level_position, 1, 0.0
     );
@@ -103,8 +103,9 @@ void Game::load_tilemap() {
     );
 
     entt::entity second_building_level {registry.create()};
-    glm::ivec2 second_building_level_position {tilemap.grid_to_pixel({8, 0})};
-    second_building_level_position -= glm::ivec2{-1, (constants::MIN_TILE_DEPTH * 3) + 13};
+    glm::ivec2 second_building_level_position {
+        building_level_position -= glm::ivec2{0, constants::MAX_TILE_DEPTH}
+    };
     registry.emplace<Transform>(
         second_building_level, second_building_level_position, 2, 0.0
     );
@@ -116,8 +117,9 @@ void Game::load_tilemap() {
     );
 
     entt::entity final_building_level {registry.create()};
-    glm::ivec2 final_building_level_position {tilemap.grid_to_pixel({8, 0})};
-    final_building_level_position -= glm::ivec2{-1, (constants::MIN_TILE_DEPTH * 4) + 11};
+    glm::ivec2 final_building_level_position {
+        second_building_level_position -= glm::ivec2{0, constants::MAX_TILE_DEPTH}
+    };
     registry.emplace<Transform>(
         final_building_level, final_building_level_position, 3, 0.0
     );
@@ -253,7 +255,7 @@ void Game::render() {
 
             for (int i=0; i<5; i++) {
                 glm::ivec2 point {
-                    (constants::tile_edge_points[i] + start_point)
+                    (constants::TILE_EDGE_POINTS[i] + start_point)
                     //  + glm::ivec2{0, constants::MIN_TILE_DEPTH} 
                 };
                 points_to_draw[i] = SDL_Point{point.x, point.y}; 

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -191,43 +191,32 @@ void Game::render() {
         render_imgui_gui(renderer, registry, mouse);
 
         if (mouse.is_on_world_grid()) {
+
             glm::ivec2 start_point {
-                tilemap.grid_to_pixel(mouse.get_grid_position())
+                tilemap.grid_to_pixel(mouse.get_grid_position()) - 
+                camera_position
             };
 
-            start_point.x -= camera_position.x;
-            start_point.y -= (camera_position.y + constants::MIN_TILE_DEPTH);
-
-            SDL_Point my_points[] = {
-                SDL_Point{
-                    start_point.x, start_point.y + constants::TILE_SIZE_HALF.y
-                },
-                SDL_Point{
-                    start_point.x + constants::TILE_SIZE_HALF.x, 
-                    start_point.y
-                },
-                SDL_Point{
-                    start_point.x + constants::TILE_SIZE.x, 
-                    start_point.y + constants::TILE_SIZE_HALF.y
-                },
-                SDL_Point{
-                    start_point.x + constants::TILE_SIZE_HALF.x, 
-                    start_point.y + constants::TILE_SIZE.y
-                },
-                SDL_Point{
-                    start_point.x,
-                    start_point.y + constants::TILE_SIZE_HALF.y
-                }
-            };
+            start_point.y -= constants::MIN_TILE_DEPTH;
         
             SDL_SetRenderDrawColor(
                 renderer,
                 255, 0, 0, 255
             ); 
+
+            SDL_Point points_to_draw[5] {};
+
+            for (int i=0; i<5; i++) {
+                glm::ivec2 point {
+                    (constants::tile_edge_points[i] + start_point)
+                    //  + glm::ivec2{0, constants::MIN_TILE_DEPTH} 
+                };
+                points_to_draw[i] = SDL_Point{point.x, point.y}; 
+            }
         
             SDL_RenderDrawLines(
                 renderer,
-                &my_points[0],
+                &points_to_draw[0],
                 5
                 // sizeof(my_points)
             );

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -180,7 +180,7 @@ void Game::render() {
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
     SDL_RenderClear(renderer);
 
-    const SDL_Rect& camera_position {camera->get_position()};
+    const glm::ivec2 camera_position {camera->get_position()};
 
     registry.sort<Transform>(transform_comparison);
 

--- a/src/engine/mouse.cpp
+++ b/src/engine/mouse.cpp
@@ -46,7 +46,11 @@ const bool Mouse::has_moved_this_frame() const {
 }
 
 const bool Mouse::is_on_world_grid() const {
-    return grid_position.x >= 0 && grid_position.y >= 0;
+    return 
+        grid_position.x >= 0 && 
+        grid_position.y >= 0 && 
+        grid_position.x < constants::MAP_SIZE_N_TILES &&
+        grid_position.y < constants::MAP_SIZE_N_TILES;
 }
 
 const uint32_t Mouse::get_mouse_state() const {

--- a/src/engine/mouse.cpp
+++ b/src/engine/mouse.cpp
@@ -16,14 +16,14 @@ Mouse::~Mouse() {
     spdlog::info("Mouse destructor called.");
 }
 
-void Mouse::update(const SDL_Rect& camera) {
+void Mouse::update(const glm::ivec2& camera_position) {
     // Update the current & previous window position
     window_previous_position = window_current_position;
     mouse_state = SDL_GetMouseState(&window_current_position.x, &window_current_position.y);
 
     // Update the world position
-    world_position.x = window_current_position.x + camera.x;
-    world_position.y = window_current_position.y + camera.y;
+    world_position.x = window_current_position.x + camera_position.x;
+    world_position.y = window_current_position.y + camera_position.y;
 
     // Update the current grid position
     grid_position = mousemap.pixel_to_grid(world_position);

--- a/src/engine/mouse.cpp
+++ b/src/engine/mouse.cpp
@@ -19,11 +19,13 @@ Mouse::~Mouse() {
 void Mouse::update(const glm::ivec2& camera_position) {
     // Update the current & previous window position
     window_previous_position = window_current_position;
-    mouse_state = SDL_GetMouseState(&window_current_position.x, &window_current_position.y);
+    mouse_state = SDL_GetMouseState(
+        &window_current_position.x, 
+        &window_current_position.y
+    );
 
     // Update the world position
-    world_position.x = window_current_position.x + camera_position.x;
-    world_position.y = window_current_position.y + camera_position.y;
+    world_position = window_current_position + camera_position;
 
     // Update the current grid position
     grid_position = mousemap.pixel_to_grid(world_position);

--- a/src/engine/mouse.h
+++ b/src/engine/mouse.h
@@ -22,7 +22,7 @@ class Mouse {
         Mouse(const MouseMap& mousemap);
         ~Mouse();
 
-        void update(const SDL_Rect& camera);
+        void update(const glm::ivec2& camera_position);
         const glm::ivec2& get_window_position() const;
         const glm::ivec2& get_world_position() const;
         const glm::ivec2& get_grid_position() const;

--- a/src/engine/mousemap.cpp
+++ b/src/engine/mousemap.cpp
@@ -49,26 +49,26 @@ SDL_Color MouseMap::mousemap_pixel_colour(const glm::ivec2& pixel_offset) const 
 glm::ivec2 MouseMap::pixel_colour_vector(const SDL_Colour& colour) const {
 
     if (colour.r == 255 && colour.g == 255 && colour.b == 255) {
-        return constants::directions[constants::NO_DIRECTION];
+        return constants::DIRECTIONS[constants::NO_DIRECTION];
     }
 
     if (colour.r == 255) {
-        return constants::directions[constants::LEFT];
+        return constants::DIRECTIONS[constants::LEFT];
     }
 
     if (colour.g == 255) {
-        return constants::directions[constants::UP];
+        return constants::DIRECTIONS[constants::UP];
     }
 
     if (colour.b == 255) {
-        return constants::directions[constants::RIGHT];
+        return constants::DIRECTIONS[constants::RIGHT];
     }
 
     if (colour.r == 0 && colour.g == 0 && colour.b == 0) {
-        return constants::directions[constants::DOWN];
+        return constants::DIRECTIONS[constants::DOWN];
     }
 
-    return constants::directions[constants::NO_DIRECTION];
+    return constants::DIRECTIONS[constants::NO_DIRECTION];
 }
 
 // Calculate the 'coarse' grid position tile walk map

--- a/src/engine/spritesheet.h
+++ b/src/engine/spritesheet.h
@@ -9,8 +9,6 @@
 class SpriteSheet {
     const std::string image_path;
     const std::string atlas_path;
-
-    /* TODO: the attributes perhaps should be private! */
     std::unordered_map<std::string, const SDL_Rect> sprites;
     SDL_Texture* spritesheet;
 

--- a/src/engine/systems/render.h
+++ b/src/engine/systems/render.h
@@ -17,9 +17,9 @@ glm::vec2& operator-(glm::vec2& lhs, const SDL_Rect& rhs) {
     return lhs;
 }
 
-SDL_FRect get_render_target(const Transform& transform, const Sprite& sprite, const SDL_Rect& camera) {
+SDL_FRect get_render_target(const Transform& transform, const Sprite& sprite, const glm::ivec2& camera) {
     glm::vec2 position {transform.position + sprite.offset};
-    position - camera;
+    position -= camera;
     return SDL_FRect {
         position.x,
         position.y,
@@ -30,13 +30,13 @@ SDL_FRect get_render_target(const Transform& transform, const Sprite& sprite, co
 
 void render_sprite(
     SDL_Renderer* renderer,
-    const SDL_Rect& camera,
+    const glm::ivec2& camera_position,
     const SDL_Rect& render_rect,
     const Transform& transform, 
     const Sprite& sprite,
     bool render_bounding_box
 ) {
-    SDL_FRect dest_rect {get_render_target(transform, sprite, camera)};
+    SDL_FRect dest_rect {get_render_target(transform, sprite, camera_position)};
 
     SDL_RenderCopyExF(
         renderer,
@@ -56,7 +56,7 @@ void render_sprite(
 
 void render_sprites(
     entt::registry& registry, 
-    const SDL_Rect& camera, 
+    const glm::ivec2& camera_position, 
     SDL_Renderer* renderer, 
     const SDL_Rect& render_clip_rect, 
     bool render_bounding_box
@@ -66,7 +66,7 @@ void render_sprites(
     for (auto entity: sprites) {
         const auto& transform {sprites.get<Transform>(entity)};
         const auto& sprite {sprites.get<Sprite>(entity)};
-        render_sprite(renderer, camera, render_clip_rect, transform, sprite, render_bounding_box);
+        render_sprite(renderer, camera_position, render_clip_rect, transform, sprite, render_bounding_box);
     }
 }
 

--- a/src/engine/systems/render.h
+++ b/src/engine/systems/render.h
@@ -10,13 +10,6 @@
 #include "sprite.h"
 #include "constants.h"
 
-// Allow us to perform substraction with a vec2 and an SDL_Rect
-glm::vec2& operator-(glm::vec2& lhs, const SDL_Rect& rhs) {
-    lhs.x -= rhs.x;
-    lhs.y -= rhs.y;
-    return lhs;
-}
-
 SDL_FRect get_render_target(const Transform& transform, const Sprite& sprite, const glm::ivec2& camera) {
     glm::vec2 position {transform.position + sprite.offset};
     position -= camera;

--- a/src/engine/tilemap.cpp
+++ b/src/engine/tilemap.cpp
@@ -19,7 +19,6 @@ TileMap::TileMap(entt::registry& registry)
     tilemap.reserve(pow(constants::MAP_SIZE_N_TILES, 2));
 
     // TODO - can I do this in the constructor initialiser list
-    // Create the entities associated with the map
     for (int cell=0; cell<pow(constants::MAP_SIZE_N_TILES, 2); cell++) {
         tilemap.emplace_back(registry.create());
     }

--- a/src/engine/tilemap.cpp
+++ b/src/engine/tilemap.cpp
@@ -10,7 +10,9 @@
 
 
 // Create the vector of tile entities and load the mousemap surface.
-TileMap::TileMap(entt::registry& registry) {
+TileMap::TileMap(entt::registry& registry): 
+    tilemap(pow(constants::MAP_SIZE_N_TILES, 2)) 
+{
     spdlog::info("TileMap constructor called.");
 
     // Create the entities associated with the map

--- a/src/engine/tilemap.cpp
+++ b/src/engine/tilemap.cpp
@@ -34,12 +34,15 @@ entt::entity TileMap::at(const int x, const int y) const {
 }
 
 // Public function converting x, y tilemap coordinates to screen coordinates
-glm::ivec2 TileMap::grid_to_pixel(const int x, const int y) const {
-    int x_offset {x-y};
-    int y_offset {y+x};
+glm::ivec2 TileMap::grid_to_pixel(const glm::ivec2& grid_pos) const {
+    
+    glm::ivec2 offset {
+        (grid_pos.x - grid_pos.y) * constants::TILE_SIZE_HALF.x, 
+        (grid_pos.y + grid_pos.x) * constants::TILE_SIZE_HALF.y
+    };
+
     return glm::ivec2 {
         // TODO: investigate streamlining this into a glm::vec2 op
-        constants::TILEMAP_START.x + (x_offset * constants::TILE_SIZE_HALF.x),
-        constants::TILEMAP_START.y + (y_offset * constants::TILE_SIZE_HALF.y)
+        constants::TILEMAP_START + offset
     };
 }

--- a/src/engine/tilemap.cpp
+++ b/src/engine/tilemap.cpp
@@ -15,6 +15,9 @@ TileMap::TileMap(entt::registry& registry)
 {
     spdlog::info("TileMap constructor called.");
 
+    // Reserve exactly the right amount of memory for the tilemap
+    tilemap.reserve(pow(constants::MAP_SIZE_N_TILES, 2));
+
     // TODO - can I do this in the constructor initialiser list
     // Create the entities associated with the map
     for (int cell=0; cell<pow(constants::MAP_SIZE_N_TILES, 2); cell++) {

--- a/src/engine/tilemap.cpp
+++ b/src/engine/tilemap.cpp
@@ -10,11 +10,12 @@
 
 
 // Create the vector of tile entities and load the mousemap surface.
-TileMap::TileMap(entt::registry& registry): 
-    tilemap(pow(constants::MAP_SIZE_N_TILES, 2)) 
+TileMap::TileMap(entt::registry& registry)
+    // : tilemap(pow(constants::MAP_SIZE_N_TILES, 2)) 
 {
     spdlog::info("TileMap constructor called.");
 
+    // TODO - can I do this in the constructor initialiser list
     // Create the entities associated with the map
     for (int cell=0; cell<pow(constants::MAP_SIZE_N_TILES, 2); cell++) {
         tilemap.emplace_back(registry.create());
@@ -33,14 +34,10 @@ entt::entity TileMap::at(const int x, const int y) const {
 
 // Public function converting x, y tilemap coordinates to screen coordinates
 glm::ivec2 TileMap::grid_to_pixel(const glm::ivec2& grid_pos) const {
-    
-    glm::ivec2 offset {
-        (grid_pos.x - grid_pos.y) * constants::TILE_SIZE_HALF.x, 
-        (grid_pos.y + grid_pos.x) * constants::TILE_SIZE_HALF.y
-    };
-
     return glm::ivec2 {
-        // TODO: investigate streamlining this into a glm::vec2 op
-        constants::TILEMAP_START + offset
+        constants::TILEMAP_START + (
+            glm::ivec2(grid_pos.x - grid_pos.y, grid_pos.y + grid_pos.x) * 
+            constants::TILE_SIZE_HALF
+        )
     };
 }

--- a/src/engine/tilemap.h
+++ b/src/engine/tilemap.h
@@ -1,8 +1,6 @@
 #ifndef TILEMAP_H
 #define TILEMAP_H
 
-#include <cmath>
-
 #include <entt/entt.hpp>
 #include <vector>
 #include <glm/glm.hpp>

--- a/src/engine/tilemap.h
+++ b/src/engine/tilemap.h
@@ -12,7 +12,7 @@ class TileMap {
         TileMap(entt::registry& registry);
         ~TileMap();
         entt::entity at(const int x, const int y) const;
-        glm::ivec2 grid_to_pixel(const int x, const int y) const;
+        glm::ivec2 grid_to_pixel(const glm::ivec2& grid_pos) const;
 };
 
 #endif

--- a/src/engine/tilemap.h
+++ b/src/engine/tilemap.h
@@ -1,14 +1,18 @@
 #ifndef TILEMAP_H
 #define TILEMAP_H
 
+#include <cmath>
+
 #include <entt/entt.hpp>
 #include <vector>
 #include <glm/glm.hpp>
 
+#include "constants.h"
+
 class TileMap {
     std::vector<entt::entity> tilemap;
     
-    public:
+    public: 
         TileMap(entt::registry& registry);
         ~TileMap();
         entt::entity at(const int x, const int y) const;


### PR DESCRIPTION
This PR implements the changes needed to **crudely** highlight an 'active' (mouse-over) tile on the grid.

### Changes

 - Update the `Camera` member `camera_position` to `camera_area` to indicate that the member has positional and magnitude (height width) data
 - Update the `Camera::get_position()` member to return an ivec2 of only the position (X,Y) as required when called
 - Update the default sprite offset logic 
    - Use "bottom middle" offset (e.g. align the middle of the sprite to the middle of the standard tile at that position, align the bottom of the sprite to the bottom of the standard tile at that position)
    - "Right align" by using ceil division logic to cater for instances where there is no exact "middle" for the sprite width (e.g. the sprite width is an odd number)
  - Update some constant names to uppercase for consistency
  - Added `POINTS_ON_TILE` / `TILE_EDGE_POINTS` constants to allow reference to a const representation of the tile shape (rectangle and diametric, respectively) 
  - Added some **temporary** code to:
    - Render the diametric tile lines for the selected tile in debug mode;
    - Place some reference tile sprites (buildings, roads) onto the 'default' grid
  - Update `Mouse::update()` member to utilise the `camera_position` ivec2 (instead of the SDL_Rect as previous)
  - Fix a bug in `Mouse::is_on_world_grid()` whereby the function did not recognise when the mouse had exceeded the positive limit of the tilemap (e.g. would previously indicate when the coordinates for a given tile contained a negative number, but not if the coordinates exceeded the specified map size)
  - Improved the `TileMap` type by:
    - Updating the constructor to reserve the memory required for the individual tiles in advance
    - Representing the TileMap as a single vector and utilising consts representing the 'width' of the grid to perform x, y operations (e.g. fetch a tile a x, y position) - TileMap was previously a vector of vectors
    - Streamlining the `grid_to_pixel()` method by utilising ivec2 operator overloads

### Issues

 - The code is not sensitive to the fact that there are a couple of different possible "heights" for un-developed tiles (33, 34px); works for the "shallower" of the two
 - The code which creates the necessary "tile" (highlight) shape is 'orphaned' / does not have an appropriate 'home' (currently in `game.cpp`)
 - There is some placeholder code which creates the 'test' tilemap, including a building - the building logic is not built yet/tbd and this placeholder code needs to be taken out! 