### PR TITLE
57 enable the creation of buildingsthe addition of levels

### DIFF
--- a/src/engine/components/sprite.h
+++ b/src/engine/components/sprite.h
@@ -9,12 +9,12 @@
 struct Sprite {
     // to be replaced with an asset identifier?
     SDL_Texture* texture;
-    const SDL_Rect& source_rect;
-    const glm::vec2 offset;
+    SDL_Rect source_rect;
+    glm::vec2 offset;
 
     Sprite(
         SDL_Texture* texture,
-        const SDL_Rect& source_rect
+        SDL_Rect source_rect
     ): 
         texture{texture}, 
         source_rect{source_rect},
@@ -41,6 +41,39 @@ struct Sprite {
             + ((constants::TILE_SIZE.x - source_rect.w) % 2 != 0),
             constants::TILE_SIZE.y - source_rect.h
         } {}
+
+        Sprite(
+            SDL_Texture* texture,
+            SDL_Rect source_rect,
+            glm::vec2 in_offset
+        ): 
+            texture{texture}, 
+            source_rect{source_rect},
+            /* 
+                TODO: determine how the offset should work.
+    
+                Here, we basically determine that the BOTTOM MIDDLE of the portion
+                of the texture we're rendering should be aligned to the BOTTOM MIDDLE
+                of the tile we're rendering it into.
+    
+                NOTE that the "middle" is offset to the right, for a positive difference
+                (e.g. where the spite is smaller than a standard tile) in the case that 
+                the width of the source rect is not evenly divisible by two.
+    
+                The logic used to do the offset (ceil division) will potentially have
+                the inverse affect in the case it's used when the sprite is larger than
+                a standard tile.
+    
+                Will leave for now since we don't have any scenarios where that's the
+                case.
+            */
+            offset{
+                glm::vec2{
+                    ((constants::TILE_SIZE.x - source_rect.w) / 2)
+                    + ((constants::TILE_SIZE.x - source_rect.w) % 2 != 0),
+                    constants::TILE_SIZE.y - source_rect.h
+                 } - in_offset
+            } {}
 };
 
 #endif

--- a/src/engine/components/sprite.h
+++ b/src/engine/components/sprite.h
@@ -6,18 +6,33 @@
 
 #include "constants.h"
 
+/*
+    TODO: understand the implication/options re. inline function definition
+    in the header file
+*/
+
+inline glm::vec2 get_offset(const SDL_Rect& source_rect) {
+    return glm::vec2{
+        ((constants::TILE_SIZE.x - source_rect.w) / 2)
+        + ((constants::TILE_SIZE.x - source_rect.w) % 2 != 0),
+        constants::TILE_SIZE.y - source_rect.h    
+    };
+}
+
 struct Sprite {
     // to be replaced with an asset identifier?
     SDL_Texture* texture;
-    SDL_Rect source_rect;
-    glm::vec2 offset;
+    const SDL_Rect source_rect;
+    const glm::vec2 offset;
 
     Sprite(
         SDL_Texture* texture,
-        SDL_Rect source_rect
+        const SDL_Rect source_rect,
+        const glm::vec2 in_offset = {0,0}
     ): 
         texture{texture}, 
         source_rect{source_rect},
+        
         /* 
             TODO: determine how the offset should work.
 
@@ -36,44 +51,8 @@ struct Sprite {
             Will leave for now since we don't have any scenarios where that's the
             case.
         */
-        offset{
-            ((constants::TILE_SIZE.x - source_rect.w) / 2)
-            + ((constants::TILE_SIZE.x - source_rect.w) % 2 != 0),
-            constants::TILE_SIZE.y - source_rect.h
-        } {}
 
-        Sprite(
-            SDL_Texture* texture,
-            SDL_Rect source_rect,
-            glm::vec2 in_offset
-        ): 
-            texture{texture}, 
-            source_rect{source_rect},
-            /* 
-                TODO: determine how the offset should work.
-    
-                Here, we basically determine that the BOTTOM MIDDLE of the portion
-                of the texture we're rendering should be aligned to the BOTTOM MIDDLE
-                of the tile we're rendering it into.
-    
-                NOTE that the "middle" is offset to the right, for a positive difference
-                (e.g. where the spite is smaller than a standard tile) in the case that 
-                the width of the source rect is not evenly divisible by two.
-    
-                The logic used to do the offset (ceil division) will potentially have
-                the inverse affect in the case it's used when the sprite is larger than
-                a standard tile.
-    
-                Will leave for now since we don't have any scenarios where that's the
-                case.
-            */
-            offset{
-                glm::vec2{
-                    ((constants::TILE_SIZE.x - source_rect.w) / 2)
-                    + ((constants::TILE_SIZE.x - source_rect.w) % 2 != 0),
-                    constants::TILE_SIZE.y - source_rect.h
-                 } - in_offset
-            } {}
+        offset{get_offset(source_rect) - in_offset} {}
 };
 
 #endif

--- a/src/engine/components/sprite.h
+++ b/src/engine/components/sprite.h
@@ -22,7 +22,7 @@ inline glm::vec2 get_offset(const SDL_Rect& source_rect) {
 struct Sprite {
     // to be replaced with an asset identifier?
     SDL_Texture* texture;
-    const SDL_Rect source_rect;
+    const SDL_Rect source_rect;     // using a ref. as input breaks - why?
     const glm::vec2 offset;
 
     Sprite(

--- a/src/engine/components/sprite.h
+++ b/src/engine/components/sprite.h
@@ -22,12 +22,12 @@ inline glm::vec2 get_offset(const SDL_Rect& source_rect) {
 struct Sprite {
     // to be replaced with an asset identifier?
     SDL_Texture* texture;
-    const SDL_Rect source_rect;     // using a ref. as input breaks - why?
+    const SDL_Rect source_rect;
     const glm::vec2 offset;
 
     Sprite(
         SDL_Texture* texture,
-        const SDL_Rect source_rect,
+        const SDL_Rect& source_rect,
         const glm::vec2 in_offset = {0,0}
     ): 
         texture{texture}, 

--- a/src/engine/constants.h
+++ b/src/engine/constants.h
@@ -60,6 +60,10 @@ namespace constants {
         "kenney_isometric-buildings-1/Spritesheet/buildingTiles_sheet.xml"
     };
 
+    const std::string MOUSE_MAP_PNG_PATH {
+        "/home/marv/Documents/Projects/isometric-game/assets/mousemap.png"
+    };
+
     enum Directions {
         NO_DIRECTION,
         LEFT,

--- a/src/engine/constants.h
+++ b/src/engine/constants.h
@@ -16,7 +16,7 @@ namespace constants {
     inline constexpr glm::ivec2 TILE_SIZE_HALF          {TILE_SIZE / 2};
     
     inline constexpr int MAP_BORDER_PX                  {100};
-    inline constexpr int MAP_SIZE_N_TILES               {20};
+    inline constexpr int MAP_SIZE_N_TILES               {10};
     inline constexpr glm::ivec2 MAP_SIZE_PX             {TILE_SIZE * MAP_SIZE_N_TILES};
 
     inline constexpr glm::ivec2 RENDER_SPACE_SIZE_PX    {MAP_SIZE_PX + (MAP_BORDER_PX * 2)};

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -30,7 +30,7 @@
 Game::Game(): 
     registry{entt::registry()}, 
     tilemap{registry},
-    mousemap{"/home/marv/Documents/Projects/isometric-game/assets/mousemap.png"},
+    mousemap{constants::MOUSE_MAP_PNG_PATH},
     mouse{mousemap}
 {
     spdlog::info("Game constructor called.");
@@ -59,9 +59,10 @@ void Game::load_tilemap() {
     for (int y=0; y<constants::MAP_SIZE_N_TILES; y++) {
         for (int x=0; x<constants::MAP_SIZE_N_TILES; x++) {
 
-            glm::ivec2 position {tilemap.grid_to_pixel({x, y})};
+            glm::ivec2 position {tilemap.at(x, y).world_position()};
+            // glm::ivec2 position {tilemap.grid_to_pixel({x, y})};
 
-            entt::entity entity {tilemap.at(x, y)};
+            entt::entity entity {tilemap.at(x, y).get_entity()};
             
             registry.emplace<Transform>(entity, position, 0, 0.0);
 
@@ -89,46 +90,31 @@ void Game::load_tilemap() {
         }
     }
 
-    entt::entity building_level {registry.create()};
-    glm::ivec2 building_level_position {tilemap.grid_to_pixel({8, 0})};
-    building_level_position -= glm::ivec2{0, constants::GROUND_FLOOR_BUILDING_OFFSET};
-    registry.emplace<Transform>(
-        building_level, building_level_position, 1, 0.0
-    );
-
-    registry.emplace<Sprite>(
-        building_level, 
+    tilemap.at(8, 0).add_building_level(
         building_tiles->get_spritesheet_texture(),
         building_tiles->get_sprite_rect("buildingTiles_043.png")
     );
 
-    entt::entity second_building_level {registry.create()};
-    glm::ivec2 second_building_level_position {
-        building_level_position -= glm::ivec2{0, constants::MAX_TILE_DEPTH}
-    };
-    registry.emplace<Transform>(
-        second_building_level, second_building_level_position, 2, 0.0
-    );
-
-    registry.emplace<Sprite>(
-        second_building_level, 
+    tilemap.at(8, 0).add_building_level(
         building_tiles->get_spritesheet_texture(),
         building_tiles->get_sprite_rect("buildingTiles_043.png")
     );
 
-    entt::entity final_building_level {registry.create()};
-    glm::ivec2 final_building_level_position {
-        second_building_level_position -= glm::ivec2{0, constants::MAX_TILE_DEPTH}
-    };
-    registry.emplace<Transform>(
-        final_building_level, final_building_level_position, 3, 0.0
+    tilemap.at(8, 0).add_building_level(
+        building_tiles->get_spritesheet_texture(),
+        building_tiles->get_sprite_rect("buildingTiles_043.png")
     );
 
-    registry.emplace<Sprite>(
-        final_building_level, 
+    tilemap.at(8, 0).add_building_level(
         building_tiles->get_spritesheet_texture(),
-        building_tiles->get_sprite_rect("buildingTiles_058.png")
+        building_tiles->get_sprite_rect("buildingTiles_043.png")
     );
+
+    tilemap.at(8, 0).add_building_level(
+        building_tiles->get_spritesheet_texture(),
+        building_tiles->get_sprite_rect("buildingTiles_043.png")
+    );
+
 }
 
 entt::entity Game::create_entity() {

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -60,7 +60,6 @@ void Game::load_tilemap() {
         for (int x=0; x<constants::MAP_SIZE_N_TILES; x++) {
 
             glm::ivec2 position {tilemap.at(x, y).world_position()};
-            // glm::ivec2 position {tilemap.grid_to_pixel({x, y})};
 
             entt::entity entity {tilemap.at(x, y).get_entity()};
             
@@ -68,12 +67,18 @@ void Game::load_tilemap() {
 
             std::string tilepng;
 
-            if (x == 8 && y == 0) {
+            if ((x == 8 || x == 7) && y == 0) {
                 registry.emplace<Sprite>(
                     entity, 
                     building_tiles->get_spritesheet_texture(),
                     building_tiles->get_sprite_rect("buildingTiles_014.png")
                 );
+            } else if (x == 6 && y == 2) {
+                registry.emplace<Sprite>(
+                    entity, 
+                    building_tiles->get_spritesheet_texture(),
+                    building_tiles->get_sprite_rect("buildingTiles_028.png")
+                );  
             } else if (y==1) {
                 registry.emplace<Sprite>(
                     entity, 
@@ -89,32 +94,6 @@ void Game::load_tilemap() {
             }
         }
     }
-
-    tilemap.at(8, 0).add_building_level(
-        building_tiles->get_spritesheet_texture(),
-        building_tiles->get_sprite_rect("buildingTiles_043.png")
-    );
-
-    tilemap.at(8, 0).add_building_level(
-        building_tiles->get_spritesheet_texture(),
-        building_tiles->get_sprite_rect("buildingTiles_043.png")
-    );
-
-    tilemap.at(8, 0).add_building_level(
-        building_tiles->get_spritesheet_texture(),
-        building_tiles->get_sprite_rect("buildingTiles_043.png")
-    );
-
-    tilemap.at(8, 0).add_building_level(
-        building_tiles->get_spritesheet_texture(),
-        building_tiles->get_sprite_rect("buildingTiles_043.png")
-    );
-
-    tilemap.at(8, 0).add_building_level(
-        building_tiles->get_spritesheet_texture(),
-        building_tiles->get_sprite_rect("buildingTiles_043.png")
-    );
-
 }
 
 entt::entity Game::create_entity() {

--- a/src/engine/game.h
+++ b/src/engine/game.h
@@ -38,10 +38,6 @@ class Game {
 
     // Investigate whether this is redundant!
     SDL_Rect render_rect;
-    
-    // Todo: read re. asset stores
-    std::optional<SpriteSheet> city_tiles;
-    std::optional<SpriteSheet> building_tiles;
 
     void load_spritesheets();
     void load_tilemap();
@@ -50,6 +46,11 @@ class Game {
     void render();
 
     public:
+
+        // Todo: read re. asset stores; make private if necessary
+        std::optional<SpriteSheet> city_tiles;
+        std::optional<SpriteSheet> building_tiles;
+
         Game();
         ~Game();
 

--- a/src/engine/tilemap.cpp
+++ b/src/engine/tilemap.cpp
@@ -31,34 +31,27 @@ const glm::ivec2 Tile::world_position() const {
 }
 
 entt::entity Tile::add_building_level(SDL_Texture* texture, SDL_Rect sprite_rect) {
+
+    // Create the entity and get the 'z-index'
     entt::entity& level {building_levels.emplace_back(registry.create())};
     auto vertical_level {building_levels.size()};
 
-    [[maybe_unused]] Transform my_transform {
-            registry.emplace<Transform>(
-            level, world_position(), vertical_level, 0.0
-        )
-    };
+    // Determine the vertical offset based on the building 'level'
+    int offset = constants::GROUND_FLOOR_BUILDING_OFFSET + (
+        (vertical_level == 1) ? 0 : constants::MAX_TILE_DEPTH * (vertical_level -1)
+    );
 
-    [[maybe_unused]]int offset{};
+    // Create the necessary components
+    registry.emplace<Transform>(
+        level, world_position(), vertical_level, 0.0
+    );
 
-    if (vertical_level == 1) {
-        offset = constants::GROUND_FLOOR_BUILDING_OFFSET;
-    } else {
-        offset = (
-            constants::GROUND_FLOOR_BUILDING_OFFSET + 
-            (constants::MAX_TILE_DEPTH * (vertical_level - 1))
-        );
-    }
-
-    Sprite my_sprite{
-        registry.emplace<Sprite>(
-            level,
-            texture,
-            sprite_rect,
-            glm::vec2{0, offset}
-        )
-    };
+    registry.emplace<Sprite>(
+        level,
+        texture,
+        sprite_rect,
+        glm::vec2{0, offset}
+    );
 
     return level;
 }

--- a/src/engine/tilemap.cpp
+++ b/src/engine/tilemap.cpp
@@ -30,6 +30,10 @@ const glm::ivec2 Tile::world_position() const {
     };
 }
 
+Tile::~Tile() {
+    registry.destroy(entity);
+}
+
 entt::entity Tile::add_building_level(SDL_Texture* texture, SDL_Rect sprite_rect) {
 
     // Create the entity and get the 'z-index'

--- a/src/engine/tilemap.cpp
+++ b/src/engine/tilemap.cpp
@@ -34,7 +34,12 @@ Tile::~Tile() {
     registry.destroy(entity);
 }
 
-entt::entity Tile::add_building_level(SDL_Texture* texture, SDL_Rect sprite_rect) {
+entt::entity Tile::add_building_level(SDL_Texture* texture, const SDL_Rect sprite_rect) {
+
+    /*
+        TODO: there's potentially some logic to be written here for 
+        e.g. ensuring that a new level isn't created above a roof
+    */
 
     // Create the entity and get the 'z-index'
     entt::entity& level {building_levels.emplace_back(registry.create())};
@@ -62,15 +67,13 @@ entt::entity Tile::add_building_level(SDL_Texture* texture, SDL_Rect sprite_rect
 
 
 // Create the vector of tile entities and load the mousemap surface.
-TileMap::TileMap(entt::registry& registry)
-    // : tilemap(pow(constants::MAP_SIZE_N_TILES, 2)) 
-{
+TileMap::TileMap(entt::registry& registry) {
     spdlog::info("TileMap constructor called.");
 
     // Reserve exactly the right amount of memory for the tilemap
     tilemap.reserve(pow(constants::MAP_SIZE_N_TILES, 2));
 
-    // TODO - can I do this in the constructor initialiser list
+    // Emplace entities into the vector
     for (int cell=0; cell<pow(constants::MAP_SIZE_N_TILES, 2); cell++) {
         glm::ivec2 grid_position{};
 

--- a/src/engine/tilemap.cpp
+++ b/src/engine/tilemap.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <iostream>
 
 #include "SDL2/SDL_image.h"
 #include "SDL2/SDL.h"
@@ -7,6 +8,60 @@
 
 #include "tilemap.h"
 #include "constants.h"
+
+#include "components/transform.h"
+#include "components/sprite.h"
+
+Tile::Tile(entt::registry& registry, const glm::ivec2 grid_position): 
+    registry{registry}, 
+    grid_position{grid_position}, 
+    entity{registry.create()}
+{}
+
+const glm::ivec2 Tile::world_position() const {
+    return glm::ivec2 {
+        constants::TILEMAP_START + (
+            glm::ivec2(
+                grid_position.x - grid_position.y, 
+                grid_position.y + grid_position.x
+            ) * 
+            constants::TILE_SIZE_HALF
+        )
+    };
+}
+
+entt::entity Tile::add_building_level(SDL_Texture* texture, SDL_Rect sprite_rect) {
+    entt::entity& level {building_levels.emplace_back(registry.create())};
+    auto vertical_level {building_levels.size()};
+
+    [[maybe_unused]] Transform my_transform {
+            registry.emplace<Transform>(
+            level, world_position(), vertical_level, 0.0
+        )
+    };
+
+    [[maybe_unused]]int offset{};
+
+    if (vertical_level == 1) {
+        offset = constants::GROUND_FLOOR_BUILDING_OFFSET;
+    } else {
+        offset = (
+            constants::GROUND_FLOOR_BUILDING_OFFSET + 
+            (constants::MAX_TILE_DEPTH * (vertical_level - 1))
+        );
+    }
+
+    Sprite my_sprite{
+        registry.emplace<Sprite>(
+            level,
+            texture,
+            sprite_rect,
+            glm::vec2{0, offset}
+        )
+    };
+
+    return level;
+}
 
 
 // Create the vector of tile entities and load the mousemap surface.
@@ -20,7 +75,21 @@ TileMap::TileMap(entt::registry& registry)
 
     // TODO - can I do this in the constructor initialiser list
     for (int cell=0; cell<pow(constants::MAP_SIZE_N_TILES, 2); cell++) {
-        tilemap.emplace_back(registry.create());
+        glm::ivec2 grid_position{};
+
+        if (cell < constants::MAP_SIZE_N_TILES) {
+            grid_position = {cell, 0};
+        } else {
+            grid_position = {
+                cell % constants::MAP_SIZE_N_TILES,
+                cell / constants::MAP_SIZE_N_TILES
+            };
+        }
+
+        tilemap.emplace_back(
+            registry, 
+            grid_position
+        );
     }
 }
 
@@ -30,16 +99,11 @@ TileMap::~TileMap() {
 }
 
 // Get an entity from tilemap position x, y
-entt::entity TileMap::at(const int x, const int y) const {
+Tile& TileMap::at(const int x, const int y) {
     return tilemap.at((y * constants::MAP_SIZE_N_TILES) + x);
 }
 
 // Public function converting x, y tilemap coordinates to screen coordinates
-glm::ivec2 TileMap::grid_to_pixel(const glm::ivec2& grid_pos) const {
-    return glm::ivec2 {
-        constants::TILEMAP_START + (
-            glm::ivec2(grid_pos.x - grid_pos.y, grid_pos.y + grid_pos.x) * 
-            constants::TILE_SIZE_HALF
-        )
-    };
+glm::ivec2 TileMap::grid_to_pixel(glm::ivec2 grid_pos) {
+    return at(grid_pos.x, grid_pos.y).world_position();
 }

--- a/src/engine/tilemap.h
+++ b/src/engine/tilemap.h
@@ -15,6 +15,7 @@ class Tile {
 
     public:
         Tile(entt::registry& registry, const glm::ivec2 grid_position);
+        ~Tile();
         const glm::ivec2 world_position() const;
         entt::entity add_building_level(SDL_Texture* texture, SDL_Rect sprite_rect);
         entt::entity get_entity() { return entity; }

--- a/src/engine/tilemap.h
+++ b/src/engine/tilemap.h
@@ -7,14 +7,28 @@
 
 #include "constants.h"
 
+class Tile {
+    entt::registry& registry;
+    const glm::ivec2 grid_position;
+    entt::entity entity;
+    std::vector<entt::entity> building_levels;
+
+    public:
+        Tile(entt::registry& registry, const glm::ivec2 grid_position);
+        const glm::ivec2 world_position() const;
+        entt::entity add_building_level(SDL_Texture* texture, SDL_Rect sprite_rect);
+        entt::entity get_entity() { return entity; }
+        entt::entity topmost_building_level() { return building_levels.back(); }
+};
+
 class TileMap {
-    std::vector<entt::entity> tilemap;
+    std::vector<Tile> tilemap;
     
     public: 
         TileMap(entt::registry& registry);
         ~TileMap();
-        entt::entity at(const int x, const int y) const;
-        glm::ivec2 grid_to_pixel(const glm::ivec2& grid_pos) const;
+        Tile& at(int x, int y);
+        glm::ivec2 grid_to_pixel(glm::ivec2 grid_pos);
 };
 
 #endif

--- a/src/engine/tilemap.h
+++ b/src/engine/tilemap.h
@@ -17,9 +17,12 @@ class Tile {
         Tile(entt::registry& registry, const glm::ivec2 grid_position);
         ~Tile();
         const glm::ivec2 world_position() const;
-        entt::entity add_building_level(SDL_Texture* texture, SDL_Rect sprite_rect);
+        entt::entity add_building_level(SDL_Texture* texture, const SDL_Rect sprite_rect);
         entt::entity get_entity() { return entity; }
+
+        // Awaiting definition
         entt::entity topmost_building_level() { return building_levels.back(); }
+        void remove_building_level();
 };
 
 class TileMap {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,10 +2,80 @@
 #include <glm/glm.hpp>
 #include "engine/game.h"
 
+#include "tilemap.h"
+
 int main() {
     Game game;
 
     game.initialise();
+
+    TileMap tilemap {game.get_tilemap()};
+    
+    tilemap.at(8, 0).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_043.png")
+    );
+
+    tilemap.at(8, 0).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_043.png")
+    );
+
+    tilemap.at(8, 0).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_043.png")
+    );
+
+    tilemap.at(8, 0).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_043.png")
+    );
+
+    tilemap.at(8, 0).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_043.png")
+    );
+
+    tilemap.at(7, 0).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_043.png")
+    );
+
+    tilemap.at(7, 0).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_043.png")
+    );
+
+    tilemap.at(7, 0).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_043.png")
+    );
+
+    tilemap.at(6, 2).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_053.png")
+    );
+
+    tilemap.at(6, 2).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_053.png")
+    );
+
+    tilemap.at(6, 2).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_053.png")
+    );
+
+    tilemap.at(6, 2).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_053.png")
+    );
+
+    tilemap.at(6, 2).add_building_level(
+        game.building_tiles->get_spritesheet_texture(),
+        game.building_tiles->get_sprite_rect("buildingTiles_061.png")
+    );
+
     game.run();
     game.destroy();
 }


### PR DESCRIPTION


### Changes

 - **Sprite offset calculation**: new function has been added which implements logic for calculating the "default" sprite offset; sprites are centered toward the bottom middle of the tile they're being created for, and are pushed to the right in the case that the sprite width isn't divisible into equal chunks
 - **Creation of a new Tile type**:
   - Encapsulates the entity representing a tile in the tilemap
   - (re)-implements the logic for deriving the "world" position from tile coordinates
   - Implements function enabling the creation of building "levels"
 - **Update of TileMap**:
   - Now encapsulates a vector of **Tiles** (and not entities)
   - Member function converting tile coordinates to world coordinates has been updated to use the new `Tile::world_position` method
 - Move some throwaway code for loading sprites into `main.cpp`