### PR TITLE
56 consolidate the process of highlighting a tile

### DIFF
--- a/src/engine/camera.cpp
+++ b/src/engine/camera.cpp
@@ -4,7 +4,7 @@
 
 Camera::Camera(const SDL_DisplayMode& display_mode): camera_area {
     (constants::RENDER_SPACE_SIZE_PX.x / 2) - (display_mode.w / 2),             // Initial X
-    0,                                                                          // Initial Y
+    (constants::RENDER_SPACE_SIZE_PX.y / 2) - (display_mode.h / 2),             // Initial Y
     display_mode.w,                                                             // Width
     display_mode.h                                                              // Height
 } {}

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -208,10 +208,10 @@ void Game::render() {
 
     render_sprites(registry, camera_position, renderer, render_rect, debug_mode);
 
-    // TODO: Update
     if (debug_mode) {
         render_imgui_gui(renderer, registry, mouse);
 
+        // Highlight tiles if relevant
         if (tilemap.selected_tile || mouse.is_on_world_grid()) {
 
             Tile& focus_tile {(tilemap.selected_tile) ? 

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -213,13 +213,11 @@ void Game::render() {
         render_imgui_gui(renderer, registry, mouse);
 
         if (tilemap.selected_tile || mouse.is_on_world_grid()) {
-            glm::ivec2 start_point {};
-            start_point = (tilemap.selected_tile) ? 
-                tilemap.selected_tile->world_position():
-                tilemap.grid_to_pixel(mouse.get_grid_position());
 
-            start_point -= camera_position;
-            start_point.y -= constants::MIN_TILE_DEPTH;
+            Tile& focus_tile {(tilemap.selected_tile) ? 
+                *tilemap.selected_tile:
+                tilemap.at(mouse.get_grid_position())
+            };
 
             if (!tilemap.selected_tile) {
                 SDL_SetRenderDrawColor(
@@ -233,21 +231,13 @@ void Game::render() {
                 );
             }
 
-            SDL_Point points_to_draw[5] {};
-
-            for (int i=0; i<5; i++) {
-                glm::ivec2 point {
-                    (constants::TILE_EDGE_POINTS[i] + start_point)
-                    //  + glm::ivec2{0, constants::MIN_TILE_DEPTH} 
-                };
-                points_to_draw[i] = SDL_Point{point.x, point.y}; 
-            }
-        
+            SDL_Point points_to_draw[5];
+            focus_tile.get_tile_iso_points(points_to_draw, camera_position);
+            
             SDL_RenderDrawLines(
                 renderer,
                 &points_to_draw[0],
                 5
-                // sizeof(my_points)
             );
         }
     }

--- a/src/engine/tilemap.cpp
+++ b/src/engine/tilemap.cpp
@@ -18,7 +18,7 @@ Tile::Tile(entt::registry& registry, const glm::ivec2 grid_position):
     entity{registry.create()}
 {}
 
-const glm::ivec2 Tile::world_position() const {
+glm::ivec2 Tile::world_position() const {
     return glm::ivec2 {
         constants::TILEMAP_START + (
             glm::ivec2(
@@ -99,11 +99,13 @@ TileMap::~TileMap() {
 }
 
 // Get an entity from tilemap position x, y
-Tile& TileMap::at(const int x, const int y) {
-    return tilemap.at((y * constants::MAP_SIZE_N_TILES) + x);
+Tile& TileMap::at(const glm::ivec2 position) {
+    return tilemap.at(
+        (position.y * constants::MAP_SIZE_N_TILES) + position.x
+    );
 }
 
 // Public function converting x, y tilemap coordinates to screen coordinates
 glm::ivec2 TileMap::grid_to_pixel(glm::ivec2 grid_pos) {
-    return at(grid_pos.x, grid_pos.y).world_position();
+    return at({grid_pos.x, grid_pos.y}).world_position();
 }

--- a/src/engine/tilemap.cpp
+++ b/src/engine/tilemap.cpp
@@ -109,3 +109,19 @@ Tile& TileMap::at(const glm::ivec2 position) {
 glm::ivec2 TileMap::grid_to_pixel(glm::ivec2 grid_pos) {
     return at({grid_pos.x, grid_pos.y}).world_position();
 }
+
+// Fill up an array with world-adjusted points used to highlight a tile
+void Tile::get_tile_iso_points(
+    SDL_Point* point_array, const glm::ivec2& camera_position
+) const {
+    glm::ivec2 start_point {world_position() -= camera_position};
+    start_point.y -= constants::MIN_TILE_DEPTH;
+    
+    for (int i=0; i<5; i++) {
+        glm::ivec2 point {
+            (constants::TILE_EDGE_POINTS[i] + start_point)
+            //  + glm::ivec2{0, constants::MIN_TILE_DEPTH} 
+        };
+        point_array[i] = SDL_Point{point.x, point.y}; 
+    }
+}

--- a/src/engine/tilemap.h
+++ b/src/engine/tilemap.h
@@ -4,7 +4,6 @@
 #include <entt/entt.hpp>
 #include <vector>
 #include <glm/glm.hpp>
-#include <optional>
 
 #include "constants.h"
 

--- a/src/engine/tilemap.h
+++ b/src/engine/tilemap.h
@@ -23,11 +23,18 @@ class Tile {
         glm::ivec2 get_grid_position() const { return grid_position; }
 
         entt::entity add_building_level(SDL_Texture* texture, const SDL_Rect sprite_rect);
-        entt::entity get_entity() { return entity; }
+        entt::entity get_entity() const { return entity; }
 
         // Awaiting definition
-        entt::entity topmost_building_level() { return building_levels.back(); }
+        entt::entity topmost_building_level() const { return building_levels.back(); }
         void remove_building_level();
+
+        // Not sure on the use of an out-paramter here; what's the alternative?
+        // ... Can be pretty confident that caller has allocated 5 positions,
+        // but not 100%
+        void get_tile_iso_points(
+            SDL_Point* point_array, const glm::ivec2& camera_position
+        ) const;
 };
 
 class TileMap {

--- a/src/engine/tilemap.h
+++ b/src/engine/tilemap.h
@@ -4,6 +4,7 @@
 #include <entt/entt.hpp>
 #include <vector>
 #include <glm/glm.hpp>
+#include <optional>
 
 #include "constants.h"
 
@@ -16,7 +17,11 @@ class Tile {
     public:
         Tile(entt::registry& registry, const glm::ivec2 grid_position);
         ~Tile();
-        const glm::ivec2 world_position() const;
+        
+        // Don't need to be const if we're returning a copy
+        glm::ivec2 world_position() const;
+        glm::ivec2 get_grid_position() const { return grid_position; }
+
         entt::entity add_building_level(SDL_Texture* texture, const SDL_Rect sprite_rect);
         entt::entity get_entity() { return entity; }
 
@@ -31,7 +36,10 @@ class TileMap {
     public: 
         TileMap(entt::registry& registry);
         ~TileMap();
-        Tile& at(int x, int y);
+
+        Tile* selected_tile {nullptr};
+
+        Tile& at(const glm::ivec2 position);
         glm::ivec2 grid_to_pixel(glm::ivec2 grid_pos);
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,67 +11,67 @@ int main() {
 
     TileMap tilemap {game.get_tilemap()};
     
-    tilemap.at(8, 0).add_building_level(
+    tilemap.at({8, 0}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_043.png")
     );
 
-    tilemap.at(8, 0).add_building_level(
+    tilemap.at({8, 0}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_043.png")
     );
 
-    tilemap.at(8, 0).add_building_level(
+    tilemap.at({8, 0}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_043.png")
     );
 
-    tilemap.at(8, 0).add_building_level(
+    tilemap.at({8, 0}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_043.png")
     );
 
-    tilemap.at(8, 0).add_building_level(
+    tilemap.at({8, 0}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_043.png")
     );
 
-    tilemap.at(7, 0).add_building_level(
+    tilemap.at({7, 0}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_043.png")
     );
 
-    tilemap.at(7, 0).add_building_level(
+    tilemap.at({7, 0}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_043.png")
     );
 
-    tilemap.at(7, 0).add_building_level(
+    tilemap.at({7, 0}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_043.png")
     );
 
-    tilemap.at(6, 2).add_building_level(
+    tilemap.at({6, 2}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_053.png")
     );
 
-    tilemap.at(6, 2).add_building_level(
+    tilemap.at({6, 2}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_053.png")
     );
 
-    tilemap.at(6, 2).add_building_level(
+    tilemap.at({6, 2}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_053.png")
     );
 
-    tilemap.at(6, 2).add_building_level(
+    tilemap.at({6, 2}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_053.png")
     );
 
-    tilemap.at(6, 2).add_building_level(
+    tilemap.at({6, 2}).add_building_level(
         game.building_tiles->get_spritesheet_texture(),
         game.building_tiles->get_sprite_rect("buildingTiles_061.png")
     );


### PR DESCRIPTION


### Changes

 - Updates initialisation of Camera so that it defaults to centre on the middle of the tilemap
 - Update `TileMap::at()`  to accept an `ivec2` instead of two (X, Y) ints
 - Update `Game::process_input()` to react to mouseclicks for selecting tiles 
 - Move logic for fetching the points needed to highlight tiles from the render to the Tile type
 - Add `Tile*` member to tilemap to allow tracking of "highlighted" tile