### PR TITLE
Add city tile selection drop-down

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ include_directories(
 add_executable(
     isometric-game 
     src/main.cpp 
+    src/engine/utils.cpp
     src/engine/camera.cpp
     src/engine/game.cpp
     src/engine/mouse.cpp

--- a/src/engine/components/sprite.h
+++ b/src/engine/components/sprite.h
@@ -5,25 +5,13 @@
 #include <glm/glm.hpp>
 
 #include "constants.h"
-
-/*
-    TODO: understand the implication/options re. inline function definition
-    in the header file
-*/
-
-inline glm::vec2 get_offset(const SDL_Rect& source_rect) {
-    return glm::vec2{
-        ((constants::TILE_SIZE.x - source_rect.w) / 2)
-        + ((constants::TILE_SIZE.x - source_rect.w) % 2 != 0),
-        constants::TILE_SIZE.y - source_rect.h    
-    };
-}
+#include "utils.h"
 
 struct Sprite {
     // to be replaced with an asset identifier?
     SDL_Texture* texture;
-    const SDL_Rect source_rect;
-    const glm::vec2 offset;
+    SDL_Rect source_rect;
+    glm::vec2 offset;
 
     Sprite(
         SDL_Texture* texture,

--- a/src/engine/spritesheet.cpp
+++ b/src/engine/spritesheet.cpp
@@ -2,6 +2,7 @@
 #include <cstdlib>
 #include <string>
 #include <iostream>
+#include <optional>
 
 #include <rapidxml/rapidxml_utils.hpp>
 #include <rapidxml/rapidxml_print.hpp>
@@ -81,4 +82,25 @@ const SDL_Rect& SpriteSheet::get_sprite_rect(const std::string& sprite_name) con
 
 SDL_Texture* SpriteSheet::get_spritesheet_texture() const {
     return spritesheet;
+}
+
+bool operator==(const SDL_Rect& lhs, const SDL_Rect& rhs) {
+    return 
+        lhs.x == rhs.x &&
+        lhs.y == rhs.y &&
+        lhs.h == rhs.h &&
+        lhs.w == rhs.w;
+}
+
+const std::optional<std::string_view> SpriteSheet::reverse_lookup(const SDL_Rect& target_rect) const {
+    auto it = std::find_if(
+        std::begin(sprites), 
+        std::end(sprites), 
+        [&target_rect](auto&& p) { return p.second == target_rect; }
+    );
+
+    if (it == std::end(sprites))
+        return std::nullopt;
+
+    return it->first;
 }

--- a/src/engine/spritesheet.h
+++ b/src/engine/spritesheet.h
@@ -2,6 +2,8 @@
 #define SPRITESHEET_H
 
 #include <unordered_map>
+#include <optional>
+
 #include <SDL2/SDL.h>
 #include <string>
 
@@ -9,10 +11,11 @@
 class SpriteSheet {
     const std::string image_path;
     const std::string atlas_path;
-    std::unordered_map<std::string, const SDL_Rect> sprites;
     SDL_Texture* spritesheet;
 
     public:
+        std::unordered_map<std::string, const SDL_Rect> sprites;
+
         SpriteSheet(const std::string& image_path,  const std::string& atlas_path, SDL_Renderer* renderer);
         SpriteSheet(const SpriteSheet&) = default;
         ~SpriteSheet();
@@ -20,6 +23,10 @@ class SpriteSheet {
         // Not yet implemented/used
         const SDL_Rect& get_sprite_rect(const std::string& sprite_name) const;
         SDL_Texture* get_spritesheet_texture() const;
+
+        // Perhaps doesn't need to be std::optional for now as some conditions on before
+        // the lookup can give us confidence on whether we'll return a value or not
+        const std::optional<std::string_view> reverse_lookup(const SDL_Rect& target_rect) const;
 };
 
 #endif

--- a/src/engine/utils.cpp
+++ b/src/engine/utils.cpp
@@ -1,0 +1,13 @@
+#include <glm/glm.hpp>
+#include <SDL2/SDL.h>
+
+#include "utils.h"
+#include "constants.h"
+
+glm::vec2 get_offset(const SDL_Rect& source_rect) {
+    return glm::vec2{
+        ((constants::TILE_SIZE.x - source_rect.w) / 2)
+        + ((constants::TILE_SIZE.x - source_rect.w) % 2 != 0),
+        constants::TILE_SIZE.y - source_rect.h    
+    };
+}

--- a/src/engine/utils.h
+++ b/src/engine/utils.h
@@ -1,0 +1,9 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <glm/glm.hpp>
+#include <SDL2/SDL.h>
+
+glm::vec2 get_offset(const SDL_Rect& source_rect);
+
+#endif


### PR DESCRIPTION
Purpose of the change in this PR is to allow for tile sprite textures to be changed in debug mode.

This is achieved by means of a drop-down box in ImGUI.

This allows switching between CITY tile sprites. More work needs to be done to figure it out for buildings, too.

Specifically:

 - The `get_offset()` function has been moved to a dedicated `utils.h`
 - Sprite source-rect and offset members have had const qualifiers removed - discussion below
 - `Game::process_input()` has been updated allow SDL2 to disregard mouse inputs which occur in the context of ImGUI UI elements
 - The render_imgui system has been updated to:
   - Accept city and building tile spritesheets as an input
   - Remove redundant clobber related to the old method of adding moveable sprites
   - Show the mouse position and the currently selected tile position independently
   - Implement a drop-down menu enabling the selection of the tile sprite; including logic to determine what the currently active tile sprite is

The PR has some problems - namely:

  - It's necessary to perform a janky 'reverse lookup' to determine what the relevant tiles "key" is for the currently active tile sprite; e.g. we use the tile sprite's SDL_Rect source_rect to 'reverse_lookup' what the key for that SDL_Rect would be in the spritesheet - should a reference to this key be stored on the sprite anyway? How can we avoid that reverse lookup?
  - To service that weird lookup, it's necessary to perform an SDL_Rect comparison (equality); a new operator overload has been added, but ideally we would not need to perform that comparison on that basis
  - Crucially, the way the city and building tiles are stored (SpriteSheet) means that it's not really very obvious how you could _easily_ switch a 'non-built' (city) tile sprite for a built (building) tile sprite.

Essentially, more thought needs to be put into:

1. How sprite/asset information should be structured to avoid needing to perform weird look-ups
2. How any new structure could lend itself to switching easily between non-built, built tile types
3. How some information inherent in the sprite type (e.g. navigability) should be captured (a new component? the navigability of a tile does not seem to be a natural property of the sprite)

I ran out of motivation a little bit to address these issues as they're a bit daunting