### PR TITLE
62 investigate creation of renderer type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
     src/engine/mousemap.cpp
     src/engine/tilemap.cpp
     src/engine/spritesheet.cpp
+    src/engine/systems/render.cpp
     libs/imgui/imgui.cpp
     libs/imgui/imgui_demo.cpp
     libs/imgui/imgui_draw.cpp

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -37,7 +37,7 @@ Game::Game():
 }
 
 Game::~Game() {
-    spdlog::info("Game destuctor called.");
+    spdlog::info("Game destructor called.");
 }
 
 void Game::load_spritesheets() {

--- a/src/engine/game.h
+++ b/src/engine/game.h
@@ -14,6 +14,7 @@
 #include "camera.h"
 #include "constants.h"
 #include "spritesheet.h"
+#include "systems/render.h"
 
 class Game {
     bool is_running {false};
@@ -24,20 +25,17 @@ class Game {
     uint64_t _last_time{0};
 
     entt::registry registry;
-    SDL_Renderer* renderer;
     SDL_Window* window;
     SDL_DisplayMode display_mode;
 
-    // Camera is smart pointer to allow late initialisation
+    // Camera, renderer are smart pointers to allow late initialisation
     std::optional<Camera> camera;
+    std::optional<Renderer> renderer;
 
     // TileMap and Mouse can be initialised during game construction
     TileMap tilemap;
     MouseMap mousemap;
     Mouse mouse;
-
-    // Investigate whether this is redundant!
-    SDL_Rect render_rect;
 
     void load_spritesheets();
     void load_tilemap();

--- a/src/engine/systems/render.cpp
+++ b/src/engine/systems/render.cpp
@@ -1,0 +1,75 @@
+#include <SDL2/SDL.h>
+
+#include "render.h"
+
+Renderer::Renderer(SDL_Window* window, const SDL_DisplayMode& display_mode, uint32_t render_flags, int index): 
+    renderer {SDL_CreateRenderer(window, index, render_flags)},
+    render_clip_rect{20, 20, display_mode.w - 40, display_mode.h - 40} {
+        
+        if (!renderer) {
+            spdlog::error("Could not initialise the SDL Renderer.");
+        }
+
+        SDL_RenderSetClipRect(renderer, &render_clip_rect);    
+    }
+
+Renderer::~Renderer() {
+    SDL_DestroyRenderer(renderer);
+}
+
+SDL_FRect get_render_target(const Transform& transform, const Sprite& sprite, const glm::ivec2& camera) {
+    glm::vec2 position {transform.position + sprite.offset};
+    position -= camera;
+    return SDL_FRect {
+        position.x,
+        position.y,
+        static_cast<float>(sprite.source_rect.w),
+        static_cast<float>(sprite.source_rect.h)
+    };
+}
+
+void Renderer::render_sprite(
+    const glm::ivec2& camera_position,
+    const Transform& transform, 
+    const Sprite& sprite,
+    bool render_bounding_box
+) {
+    SDL_FRect dest_rect {get_render_target(transform, sprite, camera_position)};
+
+    SDL_RenderCopyExF(
+        renderer,
+        sprite.texture,
+        &sprite.source_rect,
+        &dest_rect,
+        transform.rotation,
+        NULL,
+        SDL_FLIP_NONE
+    );
+
+    if (render_bounding_box && transform.z_index != 0) {
+        SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
+        SDL_RenderDrawRectF(renderer, &dest_rect);
+    }
+}
+
+void Renderer::render_sprites(
+    const entt::registry& registry, 
+    const glm::ivec2& camera_position,
+    bool render_bounding_box
+) {
+    auto sprites = registry.view<Transform, Sprite>();
+    sprites.use<Transform>();
+    for (auto entity: sprites) {
+        const auto& transform {sprites.get<Transform>(entity)};
+        const auto& sprite {sprites.get<Sprite>(entity)};
+        render_sprite(camera_position, transform, sprite, render_bounding_box);
+    }
+}
+
+void Renderer::render(const entt::registry& registry, const glm::ivec2& camera_position, bool render_bounding_box) {
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
+    SDL_RenderClear(renderer);
+
+    render_sprites(registry, camera_position, render_bounding_box);
+
+}

--- a/src/engine/systems/render.cpp
+++ b/src/engine/systems/render.cpp
@@ -1,10 +1,13 @@
 #include <SDL2/SDL.h>
+#include <spdlog/spdlog.h>
 
 #include "render.h"
 
 Renderer::Renderer(SDL_Window* window, const SDL_DisplayMode& display_mode, uint32_t render_flags, int index): 
     renderer {SDL_CreateRenderer(window, index, render_flags)},
     render_clip_rect{20, 20, display_mode.w - 40, display_mode.h - 40} {
+
+        spdlog::info("Renderer constructor called.");
         
         if (!renderer) {
             spdlog::error("Could not initialise the SDL Renderer.");
@@ -14,18 +17,8 @@ Renderer::Renderer(SDL_Window* window, const SDL_DisplayMode& display_mode, uint
     }
 
 Renderer::~Renderer() {
+    spdlog::info("Renderer destructor called.");
     SDL_DestroyRenderer(renderer);
-}
-
-SDL_FRect get_render_target(const Transform& transform, const Sprite& sprite, const glm::ivec2& camera) {
-    glm::vec2 position {transform.position + sprite.offset};
-    position -= camera;
-    return SDL_FRect {
-        position.x,
-        position.y,
-        static_cast<float>(sprite.source_rect.w),
-        static_cast<float>(sprite.source_rect.h)
-    };
 }
 
 void Renderer::render_sprite(
@@ -34,7 +27,15 @@ void Renderer::render_sprite(
     const Sprite& sprite,
     bool render_bounding_box
 ) {
-    SDL_FRect dest_rect {get_render_target(transform, sprite, camera_position)};
+    glm::vec2 position {transform.position + sprite.offset};
+    position -= camera_position;
+
+    SDL_FRect dest_rect {
+        position.x,
+        position.y,
+        static_cast<float>(sprite.source_rect.w),
+        static_cast<float>(sprite.source_rect.h)   
+    };
 
     SDL_RenderCopyExF(
         renderer,
@@ -69,7 +70,5 @@ void Renderer::render_sprites(
 void Renderer::render(const entt::registry& registry, const glm::ivec2& camera_position, bool render_bounding_box) {
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
     SDL_RenderClear(renderer);
-
     render_sprites(registry, camera_position, render_bounding_box);
-
 }

--- a/src/engine/systems/render.h
+++ b/src/engine/systems/render.h
@@ -5,62 +5,38 @@
 #include <unordered_map>
 #include <spdlog/spdlog.h>
 #include <glm/glm.hpp>
+#include <entt/entt.hpp>
 
 #include "transform.h"
 #include "sprite.h"
 #include "constants.h"
 
-SDL_FRect get_render_target(const Transform& transform, const Sprite& sprite, const glm::ivec2& camera) {
-    glm::vec2 position {transform.position + sprite.offset};
-    position -= camera;
-    return SDL_FRect {
-        position.x,
-        position.y,
-        static_cast<float>(sprite.source_rect.w),
-        static_cast<float>(sprite.source_rect.h)
-    };
-}
+class Renderer{
 
-void render_sprite(
-    SDL_Renderer* renderer,
-    const glm::ivec2& camera_position,
-    const SDL_Rect& render_rect,
-    const Transform& transform, 
-    const Sprite& sprite,
-    bool render_bounding_box
-) {
-    SDL_FRect dest_rect {get_render_target(transform, sprite, camera_position)};
-
-    SDL_RenderCopyExF(
-        renderer,
-        sprite.texture,
-        &sprite.source_rect,
-        &dest_rect,
-        transform.rotation,
-        NULL,
-        SDL_FLIP_NONE
+    void render_sprite(
+        const glm::ivec2& camera_position,
+        const Transform& transform, 
+        const Sprite& sprite,
+        bool render_bounding_box
     );
 
-    if (render_bounding_box && transform.z_index != 0) {
-        SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
-        SDL_RenderDrawRectF(renderer, &dest_rect);
-    }
-}
+    void render_sprites(
+        const entt::registry& registry, 
+        const glm::ivec2& camera_position,
+        bool render_bounding_box
+    );
 
-void render_sprites(
-    entt::registry& registry, 
-    const glm::ivec2& camera_position, 
-    SDL_Renderer* renderer, 
-    const SDL_Rect& render_clip_rect, 
-    bool render_bounding_box
-) {
-    auto sprites = registry.view<Transform, Sprite>();
-    sprites.use<Transform>();
-    for (auto entity: sprites) {
-        const auto& transform {sprites.get<Transform>(entity)};
-        const auto& sprite {sprites.get<Sprite>(entity)};
-        render_sprite(renderer, camera_position, render_clip_rect, transform, sprite, render_bounding_box);
-    }
-}
+    public:
+        // No compelling reason to make this private yet?
+        SDL_Renderer* renderer;
+        SDL_Rect render_clip_rect;
+        
+        Renderer(SDL_Window* window, const SDL_DisplayMode& display_mode, uint32_t render_flags, int index);
+        ~Renderer();
+
+        void render(const entt::registry& registry, const glm::ivec2& camera_position, bool render_bounding_box);
+};
+
+SDL_FRect get_render_target(const Transform& transform, const Sprite& sprite, const glm::ivec2& camera);
 
 #endif

--- a/src/engine/systems/render.h
+++ b/src/engine/systems/render.h
@@ -37,6 +37,4 @@ class Renderer{
         void render(const entt::registry& registry, const glm::ivec2& camera_position, bool render_bounding_box);
 };
 
-SDL_FRect get_render_target(const Transform& transform, const Sprite& sprite, const glm::ivec2& camera);
-
 #endif


### PR DESCRIPTION
Creates a Renderer type and moves a lot of renderer-related detail into that type.

Include things like:
 - Initialising and destroying the SDL renderer
 - Creating the render_clip_rect (for which we still don't have a use?)
 - Rendering sprites (or rendercopyex)

Still not completely done because some of the rendering code (e.g. render present), and the render initialisation (for IMGUI) happens outside of this type; The IMGUI stuff essentially needs to be 'cleaned up'?