### PR TITLE
Add spatial map cell span component and logic to populate it

### DIFF
--- a/src/engine/components/spatialmapcell_span_component.h
+++ b/src/engine/components/spatialmapcell_span_component.h
@@ -1,0 +1,11 @@
+#ifndef SPATIALMAPCELLSPANCOMPONENT_H
+#define SPATIALMAPCELLSPANCOMPONENT_H
+
+#include <position.h>
+
+struct SpatialMapCellSpanComponent {
+    SpatialMapGridPosition AA;
+    SpatialMapGridPosition BB;
+};
+
+#endif


### PR DESCRIPTION
Adds the logic necessary to cache the spatial partition grid cells a given entity may span, and to manage the creation/removal of the entity in spanned grid cells