### PR TITLE
Enabled pixel-level highlighting incl. rendering highlights in debug

### DIFF
--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -135,10 +135,6 @@ void Game::update([[maybe_unused]] const float delta_time)
 void Game::render()
 {
     // SDL_RenderSetClipRect(renderer, &camera.camera_rect);
-    const Grid<entt::entity, TileMapProjection>& tilemap {
-        registry.ctx().get<const Grid<entt::entity, TileMapProjection>>()
-    };
-
     SDL_SetRenderDrawColor(renderer.get(), 0, 0, 0, 0);
     SDL_RenderClear(renderer.get());
     RenderSystem::render(registry, renderer.get(), debug_mode);

--- a/src/engine/spritesheet.cpp
+++ b/src/engine/spritesheet.cpp
@@ -9,6 +9,38 @@
 #include <spritesheet.h>
 
 namespace {
+
+bool pixel_is_opaque(const SDL_Surface* surface, int x, int y)
+{
+    uint32_t pixel { static_cast<uint32_t*>(surface->pixels)[y * surface->w + x] };
+    uint8_t r, g, b, a;
+    SDL_GetRGBA(pixel, surface->format, &r, &g, &b, &a);
+    return a == 255; // define an opacity threshold here, e.g. for shadows
+}
+
+bool is_highlight_pixel(const SDL_Surface* surface, int x, int y)
+{
+    // If the current pixel is opaque, and
+    // - on the edge of the image; or
+    // - the either previous or the next one is not opaque
+    bool current_pixel_is_opaque { pixel_is_opaque(surface, x, y) };
+    bool is_on_x_edge { x == 0 || x == surface->w - 1 };
+    bool is_on_y_edge { y == 0 || y == surface->h - 1 };
+
+    if (is_on_x_edge || is_on_y_edge)
+        return current_pixel_is_opaque;
+
+    bool adjacent_is_transparent { false };
+    for (int y_diff = -1; y_diff <= 1 && !adjacent_is_transparent; y_diff++) {
+        for (int x_diff = -1; x_diff <= 1 && !adjacent_is_transparent; x_diff++) {
+            if (x_diff == 0 || y_diff == 0)
+                continue;
+            adjacent_is_transparent = !pixel_is_opaque(surface, x + x_diff, y + y_diff);
+        }
+    }
+    return current_pixel_is_opaque && adjacent_is_transparent;
+}
+
 std::vector<bool> get_mask(
     const SDL_Surface* surface,
     const SDL_Rect rect,
@@ -18,18 +50,31 @@ std::vector<bool> get_mask(
     std::vector<bool> output;
     int n_pixels { rect.w * rect.h };
     output.reserve(n_pixels);
-    uint32_t* pixels { static_cast<uint32_t*>(surface->pixels) };
-    int start_pixel { (rect.y * surface->w) + rect.x };
-    uint8_t r, g, b, a;
-    for (int y = 0; y < rect.h; y++) {
-        for (int x = 0; x < rect.w; x++) {
-            int current_pixel { start_pixel + (surface->w * y) + x };
-            uint32_t pixel { pixels[current_pixel] };
-            SDL_GetRGBA(pixel, surface->format, &r, &g, &b, &a);
-            output.push_back((r + g + b) != 0 && a != 0);
+    for (int rect_y = 0; rect_y < rect.h; rect_y++) {
+        for (int rect_x = 0; rect_x < rect.w; rect_x++) {
+            output.push_back(pixel_is_opaque(surface, rect.x + rect_x, rect.y + rect_y));
         }
     }
     return output;
+}
+
+void set_outline_texture(SDL_Texture* texture, SDL_Surface* surface)
+{
+    std::vector<uint32_t> outline_pixels(surface->w * surface->h, 0);
+    for (int y = 0; y < surface->h; y++) {
+        for (int x = 0; x < surface->w; x++) {
+            if (!is_highlight_pixel(surface, x, y))
+                continue;
+            outline_pixels[y * surface->w + x] = 0xFF0000FF; // red
+        }
+    }
+
+    SDL_UpdateTexture(
+        texture,
+        nullptr,
+        outline_pixels.data(),
+        surface->w * sizeof(uint32_t)
+    );
 }
 }
 
@@ -60,13 +105,28 @@ SpriteSheet::SpriteSheet(
         spdlog::info("Could not load texture from path: " + spritesheet_path);
     };
 
-    texture = std::unique_ptr<SDL_Texture, Utility::SDLDestroyer>(
-        SDL_CreateTextureFromSurface(renderer.get(), surface.get())
+    texture
+        = std::unique_ptr<SDL_Texture, Utility::SDLDestroyer>(
+            SDL_CreateTextureFromSurface(renderer.get(), surface.get())
+        );
+
+    outline_texture = std::unique_ptr<SDL_Texture, Utility::SDLDestroyer>(
+        SDL_CreateTexture(
+            renderer.get(),
+            SDL_PIXELFORMAT_RGBA8888,
+            SDL_TEXTUREACCESS_STATIC,
+            surface->w,
+            surface->h
+        )
     );
 
-    if (!texture) {
+    SDL_SetTextureBlendMode(outline_texture.get(), SDL_BLENDMODE_BLEND);
+
+    if (!texture || !outline_texture) {
         spdlog::info("Could not load texture from surface using image: " + spritesheet_path);
     };
+
+    set_outline_texture(outline_texture.get(), surface.get());
 
     std::ifstream input { atlas_path };
     nlohmann::json data = nlohmann::json::parse(input);

--- a/src/engine/spritesheet.h
+++ b/src/engine/spritesheet.h
@@ -30,6 +30,7 @@ struct SpriteDefinition {
 
 struct SpriteSheet {
     std::unique_ptr<SDL_Texture, Utility::SDLDestroyer> texture;
+    std::unique_ptr<SDL_Texture, Utility::SDLDestroyer> outline_texture;
     std::unordered_map<std::string, SpriteDefinition> sprites;
 
     SpriteSheet(

--- a/src/engine/systems/render_system.cpp
+++ b/src/engine/systems/render_system.cpp
@@ -131,6 +131,18 @@ void render(const entt::registry& registry, SDL_Renderer* renderer, [[maybe_unus
             NULL,
             SDL_FLIP_NONE
         );
+
+        if (debug_mode && renderable.mouseover) {
+            SDL_RenderCopyEx(
+                renderer,
+                spritesheet.outline_texture.get(),
+                &renderable.sprite->source_rect,
+                &target_rect,
+                renderable.transform->rotation,
+                NULL,
+                SDL_FLIP_NONE
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Adds the logic necessary to:

- Create a texture of highlights from an input spritesheet
- Render the highlights for a given entity in debug mode in case the entity is mouseover'd