### PR TITLE
Remove component creation order dependency

### DIFF
--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -90,10 +90,14 @@ void Game::initialise()
 
     registry.on_construct<SpriteComponent>().connect<&SpatialMapSystem::emplace_entity>();
     registry.on_destroy<SpriteComponent>().connect<&SpatialMapSystem::remove_entity>();
+
+    registry.on_construct<TransformComponent>().connect<&SpatialMapSystem::emplace_entity>();
     registry.on_update<TransformComponent>().connect<&SpatialMapSystem::update_entity>();
+    registry.on_destroy<TransformComponent>().connect<&SpatialMapSystem::remove_entity>();
 
     registry.on_construct<SegmentComponent>().connect<&SpatialMapSystem::emplace_segment>();
     registry.on_destroy<SegmentComponent>().connect<&SpatialMapSystem::remove_segment>();
+    
     registry.on_construct<SegmentComponent>().connect<&GraphSystem::emplace_segment>();
     registry.on_destroy<SegmentComponent>().connect<&GraphSystem::remove_segment>();
 

--- a/src/engine/systems/spatialmap_system.cpp
+++ b/src/engine/systems/spatialmap_system.cpp
@@ -117,15 +117,22 @@ void update_entity(entt::registry& registry, entt::entity entity)
 
 void emplace_entity(entt::registry& registry, entt::entity entity)
 {
+
+    if (!registry.all_of<SpriteComponent, TransformComponent>(entity))
+        return;
+
     const Grid<entt::entity, SpatialMapProjection>& spatial_map {
         registry.ctx().get<const Grid<entt::entity, SpatialMapProjection>>()
     };
 
     const SpatialMapCellSpanComponent& cell_span {
-        spanned_cells(
-            registry.get<const TransformComponent>(entity),
-            registry.get<const SpriteComponent>(entity),
-            registry.ctx().get<const Grid<entt::entity, SpatialMapProjection>>()
+        registry.emplace_or_replace<SpatialMapCellSpanComponent>(
+            entity,
+            spanned_cells(
+                registry.get<const TransformComponent>(entity),
+                registry.get<const SpriteComponent>(entity),
+                spatial_map
+            )
         )
     };
 


### PR DESCRIPTION
Ensures that the spatial map emplace entity logic is not dependent on the creation order for the sprite, transform components it depends on